### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,12 @@
 version: 2
 updates:
-- package-ecosystem: pip
+- package-ecosystem: "pip"
   directory: "/"
   schedule:
-    interval: weekly
-    day: saturday
-  open-pull-requests-limit: 10
+    interval: "weekly"
+    day: "saturday"
+  allow:
+    - dependency-type: "production"
+    - dependency-name: "ledgerblue"
+      dependency-type: "direct"
+    


### PR DESCRIPTION
Dependabot currently opens PRs for all dependencies, including production and development group dependencies.  

To make the Dependabot PRs more applicable, this change removes development dependencies from Dependabot PRs, and only allows production and ledgerblue dependency updates.
