### PR TITLE
Fixing weak cryptography in helper.py, utils.py and generator.py.

### DIFF
--- a/skale/utils/contracts_provision/utils.py
+++ b/skale/utils/contracts_provision/utils.py
@@ -17,22 +17,22 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
 
-import random
+from secrets import randbelow, choice
 import string
 
 
 def generate_random_ip():
-    return '.'.join('%s' % random.randint(0, 255) for i in range(4))
+    return '.'.join('%s' % randbelow(255) for _ in range(4))
 
 
 def generate_random_name(len=8):
     return ''.join(
-        random.choices(string.ascii_uppercase + string.digits, k=len)
+        choice(string.ascii_uppercase + string.digits) for _ in range(len)
     )
 
 
 def generate_random_port():
-    return random.randint(0, 60000)
+    return randbelow(60000)
 
 
 def generate_random_node_data():

--- a/skale/utils/helper.py
+++ b/skale/utils/helper.py
@@ -21,12 +21,12 @@
 import ipaddress
 import json
 import logging
-import random
 import socket
 import string
 import sys
+
 from logging import Formatter, StreamHandler
-from random import randint
+from secrets import randbelow, choice
 
 from skale.config import ENV
 
@@ -100,24 +100,24 @@ def get_abi(abi_filepath=None):
 
 
 def generate_nonce():  # pragma: no cover
-    return randint(0, 65534)
+    return randbelow(65534)
 
 
 def random_string(size=6, chars=string.ascii_lowercase):  # pragma: no cover
-    return ''.join(random.choice(chars) for x in range(size))
+    return ''.join(choice(chars) for _ in range(size))
 
 
 def generate_random_ip():  # pragma: no cover
-    return '.'.join('%s' % random.randint(0, 255) for i in range(4))
+    return '.'.join('%s' % randbelow(255) for _ in range(4))
 
 
 def generate_random_name(len=8):  # pragma: no cover
     return ''.join(
-        random.choices(string.ascii_uppercase + string.digits, k=len))
+        choice(string.ascii_uppercase + string.digits) for _ in range(len))
 
 
 def generate_random_port():  # pragma: no cover
-    return random.randint(0, 60000)
+    return randbelow(60000)
 
 
 def generate_custom_config(ip, ws_port):

--- a/skale/utils/random_names/generator.py
+++ b/skale/utils/random_names/generator.py
@@ -17,7 +17,7 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
 
-import random
+from secrets import choice
 from skale.utils.random_names.vocabulary import CONSTELLATIONS, STARS, \
     SOUND_AND_APPEARANCE_ADJECTIVES, POSITIVE_AND_TIME_ADJECTIVES
 
@@ -37,7 +37,7 @@ def generate_name(noun_dict, adjective_dict):
 
 
 def get_random_word_from_dict(vocabulary_dict):
-    return random.choice(vocabulary_dict).lower().replace(" ", "-")
+    return choice(vocabulary_dict).lower().replace(" ", "-")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixing weak cryptography in generation functions changing from 'random' to 'secrets' lib just outside test environment in helper.py, utils.py and generator.py.
---
This Security Hotspot is referred by RSPEC-2245 (https://rules.sonarsource.com/python/RSPEC-2245) and OWASP (https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html#secure-random-number-generation)