### PR TITLE
Update skale-contracts version to 1.0.2a26 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'pyyaml==6.0',
         'redis==5.0.3',
         'sgx.py==0.9dev5',
-        'skale-contracts==1.0.1a5',
+        'skale-contracts==1.0.2a26',
         'typing-extensions==4.9.0',
         'web3==6.20.2',
     ],


### PR DESCRIPTION
This pull request includes a small change to the `setup.py` file. The change updates the version of the `skale-contracts` dependency from `1.0.1a5` to `1.0.2a26`.

* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L46-R46): Updated `skale-contracts` dependency version to `1.0.2a26`.