### PR TITLE
Add Linker role methods, refactor address typing & update helper-scripts

### DIFF
--- a/skale/contracts/ima/mainnet/community_pool.py
+++ b/skale/contracts/ima/mainnet/community_pool.py
@@ -27,7 +27,7 @@ from skale.types.schain import SchainName
 
 class CommunityPool(BaseContract):
     @transaction_method
-    def recharge_user_wallet(self, schain_name: SchainName, address: int) -> TxRes:
+    def recharge_user_wallet(self, schain_name: SchainName, address: ChecksumAddress) -> TxRes:
         return self.contract.functions.rechargeUserWallet(schain_name, address)
 
     @transaction_method
@@ -42,7 +42,7 @@ class CommunityPool(BaseContract):
     def set_multiplier(self, new_numerator: int, new_divider: int) -> TxRes:
         return self.contract.functions.setMultiplier(new_numerator, new_divider)
 
-    def get_balance(self, address: int, schain_name: SchainName) -> int:
+    def get_balance(self, address: ChecksumAddress, schain_name: SchainName) -> int:
         return self.contract.functions.getBalance(address, schain_name).call()
 
     def check_user_balance(self, schain_name: SchainName, receiver: int) -> bool:
@@ -61,7 +61,7 @@ class CommunityPool(BaseContract):
     def admin_role(self) -> bytes:
         return self.contract.functions.DEFAULT_ADMIN_ROLE().call()
 
-    def has_role(self, role: bytes, address: int) -> bool:
+    def has_role(self, role: bytes, address: ChecksumAddress) -> bool:
         return self.contract.functions.hasRole(role, address).call()
 
     @transaction_method

--- a/skale/contracts/ima/mainnet/deposit_box_erc1155.py
+++ b/skale/contracts/ima/mainnet/deposit_box_erc1155.py
@@ -17,6 +17,7 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
 
+from eth_typing import ChecksumAddress
 from skale.contracts.base_contract import BaseContract, transaction_method
 from skale.transactions.result import TxRes
 from skale.types.schain import SchainName
@@ -26,19 +27,24 @@ class DepositBoxERC1155(BaseContract):
     """Class deposit"""
 
     @transaction_method
-    def add_erc1155_token(self, schain_name: SchainName, address: int) -> TxRes:
+    def add_erc1155_token(self, schain_name: SchainName, address: ChecksumAddress) -> TxRes:
         return self.contract.functions.addERC1155TokenByOwner(schain_name, address)
 
     @transaction_method
     def deposit_erc1155(
-        self, schain_name: SchainName, address: int, token_id: int, amount: int
+        self, schain_name: SchainName, address: ChecksumAddress, token_id: int, amount: int
     ) -> TxRes:
         """Deposit ERC1155"""
         return self.contract.functions.depositERC1155(schain_name, address, token_id, amount)
 
     @transaction_method
     def deposit_direct_erc1155(
-        self, schain_name: SchainName, address: int, token_id: int, amount: int, receiver: int
+        self,
+        schain_name: SchainName,
+        address: ChecksumAddress,
+        token_id: int,
+        amount: int,
+        receiver: int,
     ) -> TxRes:
         """Direct deposit ERC1155"""
         return self.contract.functions.depositERC1155Direct(
@@ -47,7 +53,7 @@ class DepositBoxERC1155(BaseContract):
 
     @transaction_method
     def deposit_erc1155_batch(
-        self, schain_name: SchainName, address: int, ids: list, amount: list
+        self, schain_name: SchainName, address: ChecksumAddress, ids: list, amount: list
     ) -> TxRes:
         return self.contract.functions.depositERC1155Batch(schain_name, address, ids, amount)
 

--- a/skale/contracts/ima/mainnet/deposit_box_erc20.py
+++ b/skale/contracts/ima/mainnet/deposit_box_erc20.py
@@ -39,16 +39,18 @@ class DepositBoxERC20(BaseContract):
         return self.contract.functions.disableWhitelist(schain_name)
 
     @transaction_method
-    def add_erc20_token(self, schain_name: SchainName, address: int) -> TxRes:
+    def add_erc20_token(self, schain_name: SchainName, address: ChecksumAddress) -> TxRes:
         return self.contract.functions.addERC20TokenByOwner(schain_name, address)
 
     @transaction_method
-    def deposit_erc20(self, schain_name: SchainName, address: int, amount: int) -> TxRes:
+    def deposit_erc20(
+        self, schain_name: SchainName, address: ChecksumAddress, amount: int
+    ) -> TxRes:
         return self.contract.functions.depositERC20(schain_name, address, amount)
 
     @transaction_method
     def deposit_erc20_direct(
-        self, schain_name: SchainName, address: int, amount: int, receiver: int
+        self, schain_name: SchainName, address: ChecksumAddress, amount: int, receiver: int
     ) -> TxRes:
         return self.contract.functions.depositERC20Direct(schain_name, address, amount, receiver)
 
@@ -65,10 +67,10 @@ class DepositBoxERC20(BaseContract):
         return self.contract.functions.setArbitrageDuration(schain_name, delay)
 
     @transaction_method
-    def trust_receiver(self, schain_name: SchainName, address: int) -> TxRes:
+    def trust_receiver(self, schain_name: SchainName, address: ChecksumAddress) -> TxRes:
         return self.contract.functions.trustReceiver(schain_name, address)
 
-    def is_receiver_trusted(self, schain_name: SchainName, address: int) -> bool:
+    def is_receiver_trusted(self, schain_name: SchainName, address: ChecksumAddress) -> bool:
         keccak_hash = keccak.new(data=schain_name.encode('utf8'), digest_bits=256)
         schain_id = keccak_hash.digest()
         return self.contract.functions.isReceiverTrusted(schain_id, address).call()
@@ -79,7 +81,7 @@ class DepositBoxERC20(BaseContract):
     def admin_role(self) -> bytes:
         return self.contract.functions.DEFAULT_ADMIN_ROLE().call()
 
-    def has_role(self, role: bytes, address: int) -> bool:
+    def has_role(self, role: bytes, address: ChecksumAddress) -> bool:
         return self.contract.functions.hasRole(role, address).call()
 
     @transaction_method

--- a/skale/contracts/ima/mainnet/deposit_box_erc721.py
+++ b/skale/contracts/ima/mainnet/deposit_box_erc721.py
@@ -17,6 +17,7 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
 
+from eth_typing import ChecksumAddress
 from skale.contracts.base_contract import BaseContract, transaction_method
 from skale.transactions.result import TxRes
 from skale.types.schain import SchainName
@@ -24,16 +25,18 @@ from skale.types.schain import SchainName
 
 class DepositBoxERC721(BaseContract):
     @transaction_method
-    def deposit_erc721(self, schain_name: SchainName, address: int, tokenID: int) -> TxRes:
+    def deposit_erc721(
+        self, schain_name: SchainName, address: ChecksumAddress, tokenID: int
+    ) -> TxRes:
         return self.contract.functions.depositERC721(schain_name, address, tokenID)
 
     @transaction_method
-    def add_erc721_token(self, schain_name: SchainName, address: int) -> TxRes:
+    def add_erc721_token(self, schain_name: SchainName, address: ChecksumAddress) -> TxRes:
         return self.contract.functions.addERC721TokenByOwner(schain_name, address)
 
     @transaction_method
     def deposit_erc721_direct(
-        self, schain_name: SchainName, address: int, token_id: int, receiver: int
+        self, schain_name: SchainName, address: ChecksumAddress, token_id: int, receiver: int
     ) -> TxRes:
         return self.contract.functions.depositERC721Direct(schain_name, address, token_id, receiver)
 

--- a/skale/contracts/ima/mainnet/deposit_box_erc721_wmt.py
+++ b/skale/contracts/ima/mainnet/deposit_box_erc721_wmt.py
@@ -17,6 +17,7 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
 
+from eth_typing import ChecksumAddress
 from skale.contracts.base_contract import BaseContract, transaction_method
 from skale.transactions.result import TxRes
 from skale.types.schain import SchainName
@@ -24,16 +25,18 @@ from skale.types.schain import SchainName
 
 class DepositBoxERC721WithMetadata(BaseContract):
     @transaction_method
-    def deposit_erc721(self, schain_name: SchainName, address: int, tokenID: int) -> TxRes:
+    def deposit_erc721(
+        self, schain_name: SchainName, address: ChecksumAddress, tokenID: int
+    ) -> TxRes:
         return self.contract.functions.depositERC721(schain_name, address, tokenID)
 
     @transaction_method
-    def add_erc721_token(self, schain_name: SchainName, address: int) -> TxRes:
+    def add_erc721_token(self, schain_name: SchainName, address: ChecksumAddress) -> TxRes:
         return self.contract.functions.addERC721TokenByOwner(schain_name, address)
 
     @transaction_method
     def deposit_erc721_direct(
-        self, schain_name: SchainName, address: int, token_id: int, receiver: int
+        self, schain_name: SchainName, address: ChecksumAddress, token_id: int, receiver: int
     ) -> TxRes:
         return self.contract.functions.depositERC721Direct(schain_name, address, token_id, receiver)
 

--- a/skale/contracts/ima/mainnet/linker.py
+++ b/skale/contracts/ima/mainnet/linker.py
@@ -37,7 +37,7 @@ class Linker(ImaContract):
     def linker_role(self) -> bytes:
         return self.contract.functions.LINKER_ROLE().call()
 
-    def has_role(self, role: bytes, address: int) -> bool:
+    def has_role(self, role: bytes, address: ChecksumAddress) -> bool:
         return self.contract.functions.hasRole(role, address).call()
 
     @transaction_method

--- a/skale/contracts/ima/mainnet/linker.py
+++ b/skale/contracts/ima/mainnet/linker.py
@@ -22,6 +22,7 @@ from eth_typing import ChecksumAddress
 from web3.contract.contract import ContractFunction
 
 from skale.contracts.base_contract import transaction_method
+from skale.transactions.result import TxRes
 from skale.contracts.ima_contract import ImaContract
 from skale.types.schain import SchainName
 
@@ -32,3 +33,13 @@ class Linker(ImaContract):
         self, schain_name: SchainName, mainnet_contracts: List[ChecksumAddress]
     ) -> ContractFunction:
         return self.contract.functions.connectSchain(schain_name, mainnet_contracts)
+
+    def linker_role(self) -> bytes:
+        return self.contract.functions.LINKER_ROLE().call()
+
+    def has_role(self, role: bytes, address: int) -> bool:
+        return self.contract.functions.hasRole(role, address).call()
+
+    @transaction_method
+    def grant_role(self, role: bytes, address: ChecksumAddress) -> TxRes:
+        return self.contract.functions.grantRole(role, address)

--- a/skale/contracts/ima/mainnet/message_proxy_for_mainnet.py
+++ b/skale/contracts/ima/mainnet/message_proxy_for_mainnet.py
@@ -67,7 +67,7 @@ class MessageProxyForMainnet(BaseContract):
     def grant_role(self, role: bytes, address: ChecksumAddress) -> TxRes:
         return self.contract.functions.grantRole(role, address)
 
-    def has_role(self, role: bytes, address: int) -> bool:
+    def has_role(self, role: bytes, address: ChecksumAddress) -> bool:
         return self.contract.functions.hasRole(role, address).call()
 
     def get_role_member(self, role: bytes, index: int) -> bytes:

--- a/skale/contracts/ima/schain/community_locker.py
+++ b/skale/contracts/ima/schain/community_locker.py
@@ -17,6 +17,7 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
 
+from eth_typing import ChecksumAddress
 from skale.contracts.base_contract import BaseContract, transaction_method
 from skale.transactions.result import TxRes
 from Crypto.Hash import keccak
@@ -34,18 +35,18 @@ class CommunityLocker(BaseContract):
     def constant_setter_role(self) -> bytes:
         return self.contract.functions.CONSTANT_SETTER_ROLE().call()
 
-    def has_role(self, role: bytes, address: int) -> bool:
+    def has_role(self, role: bytes, address: ChecksumAddress) -> bool:
         return self.contract.functions.hasRole(role, address).call()
 
     @transaction_method
-    def revoke_role(self, role: bytes, address: int) -> TxRes:
+    def revoke_role(self, role: bytes, address: ChecksumAddress) -> TxRes:
         return self.contract.functions.revokeRole(role, address)
 
     @transaction_method
-    def grant_role(self, role: bytes, address: int) -> TxRes:
+    def grant_role(self, role: bytes, address: ChecksumAddress) -> TxRes:
         return self.contract.functions.grantRole(role, address)
 
-    def check_allow_to_send_msg(self, schain_name: SchainName, address: int) -> int:
+    def check_allow_to_send_msg(self, schain_name: SchainName, address: ChecksumAddress) -> int:
         keccak_hash = keccak.new(data=schain_name.encode('utf8'), digest_bits=256)
         hash = keccak_hash.digest()
         return self.contract.functions.checkAllowedToSendMessage(hash, address).call()

--- a/skale/contracts/ima/schain/message_proxy_for_schain.py
+++ b/skale/contracts/ima/schain/message_proxy_for_schain.py
@@ -33,7 +33,7 @@ class MessageProxyForSchain(BaseContract):
     def constant_setter_role(self) -> bytes:
         return self.contract.functions.CONSTANT_SETTER_ROLE().call()
 
-    def has_role(self, role: bytes, address: int) -> bool:
+    def has_role(self, role: bytes, address: ChecksumAddress) -> bool:
         return self.contract.functions.hasRole(role, address).call()
 
     @transaction_method

--- a/skale/contracts/ima/schain/token_manager_erc1155.py
+++ b/skale/contracts/ima/schain/token_manager_erc1155.py
@@ -75,7 +75,7 @@ class TokenManagerERC1155(BaseContract):
     def token_registrar_role(self) -> bytes:
         return self.contract.functions.TOKEN_REGISTRAR_ROLE().call()
 
-    def has_role(self, role: bytes, address: int) -> bool:
+    def has_role(self, role: bytes, address: ChecksumAddress) -> bool:
         return self.contract.functions.hasRole(role, address).call()
 
     @transaction_method

--- a/skale/contracts/ima/schain/token_manager_erc20.py
+++ b/skale/contracts/ima/schain/token_manager_erc20.py
@@ -74,7 +74,7 @@ class TokenManagerERC20(BaseContract):
     def token_registrar_role(self) -> bytes:
         return self.contract.functions.TOKEN_REGISTRAR_ROLE().call()
 
-    def has_role(self, role: bytes, address: int) -> bool:
+    def has_role(self, role: bytes, address: ChecksumAddress) -> bool:
         return self.contract.functions.hasRole(role, address).call()
 
     @transaction_method

--- a/skale/contracts/ima/schain/token_manager_erc721.py
+++ b/skale/contracts/ima/schain/token_manager_erc721.py
@@ -38,7 +38,7 @@ class TokenManagerERC721(BaseContract):
 
     @transaction_method
     def transfer_to_schain_erc721(
-        self, schain_name: SchainName, address: int, token_id: int
+        self, schain_name: SchainName, address: ChecksumAddress, token_id: int
     ) -> TxRes:
         """address - token address on origin chain"""
         return self.contract.functions.transferToSchainERC721(schain_name, address, token_id)
@@ -53,11 +53,11 @@ class TokenManagerERC721(BaseContract):
     def token_registrar_role(self) -> bytes:
         return self.contract.functions.TOKEN_REGISTRAR_ROLE().call()
 
-    def has_role(self, role: bytes, address: int) -> bool:
+    def has_role(self, role: bytes, address: ChecksumAddress) -> bool:
         return self.contract.functions.hasRole(role, address).call()
 
     @transaction_method
-    def exit_to_main_erc721(self, address: int, token_id: int) -> TxRes:
+    def exit_to_main_erc721(self, address: ChecksumAddress, token_id: int) -> TxRes:
         return self.contract.functions.exitToMainERC721(address, token_id)
 
     @transaction_method

--- a/skale/contracts/ima/schain/token_manager_erc721_wmt.py
+++ b/skale/contracts/ima/schain/token_manager_erc721_wmt.py
@@ -40,7 +40,7 @@ class TokenManagerERC721WithMetadata(BaseContract):
 
     @transaction_method
     def transfer_to_schain_erc721(
-        self, schain_name: SchainName, address: int, token_id: int
+        self, schain_name: SchainName, address: ChecksumAddress, token_id: int
     ) -> TxRes:
         """address - token address on origin chain"""
         return self.contract.functions.transferToSchainERC721(schain_name, address, token_id)
@@ -53,13 +53,13 @@ class TokenManagerERC721WithMetadata(BaseContract):
         return self.contract.functions.AUTOMATIC_DEPLOY_ROLE().call()
 
     @transaction_method
-    def exit_to_main_erc721(self, address: int, token_id: int) -> TxRes:
+    def exit_to_main_erc721(self, address: ChecksumAddress, token_id: int) -> TxRes:
         return self.contract.functions.exitToMainERC721(address, token_id)
 
     def token_registrar_role(self) -> bytes:
         return self.contract.functions.TOKEN_REGISTRAR_ROLE().call()
 
-    def has_role(self, role: bytes, address: int) -> bool:
+    def has_role(self, role: bytes, address: ChecksumAddress) -> bool:
         return self.contract.functions.hasRole(role, address).call()
 
     @transaction_method

--- a/skale/contracts/ima/schain/token_manager_linker.py
+++ b/skale/contracts/ima/schain/token_manager_linker.py
@@ -39,7 +39,7 @@ class TokenManagerLinker(BaseContract):
     def registrar_role(self) -> bytes:
         return self.contract.functions.REGISTRAR_ROLE().call()
 
-    def has_role(self, role: bytes, address: int) -> bool:
+    def has_role(self, role: bytes, address: ChecksumAddress) -> bool:
         return self.contract.functions.hasRole(role, address).call()
 
     @transaction_method

--- a/skale/contracts/manager/delegation/delegation_controller.py
+++ b/skale/contracts/manager/delegation/delegation_controller.py
@@ -139,7 +139,7 @@ class DelegationController(SkaleManagerContract):
         """Returns list of formatted delegations for validator.
 
         :param validator_id: ID of the validator
-        :type address: int
+        :type validator_id: ValidatorId
         :returns: List of formatted delegations
         :rtype: list
         """

--- a/skale/contracts/paymaster/paymaster.py
+++ b/skale/contracts/paymaster/paymaster.py
@@ -17,6 +17,7 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
 
+from eth_typing import ChecksumAddress
 from skale.contracts.base_contract import BaseContract, transaction_method
 from skale.transactions.result import TxRes
 from skale.types.schain import SchainHash, SchainName
@@ -124,7 +125,7 @@ class Paymaster(BaseContract):
         return self.contract.functions.setNodesAmount(validator_id, amount)
 
     @transaction_method
-    def claim_for(self, validator_id: int, address: int) -> TxRes:
+    def claim_for(self, validator_id: int, address: ChecksumAddress) -> TxRes:
         return self.contract.functions.claimFor(validator_id, address)
 
     def get_schain_number(self) -> str:


### PR DESCRIPTION
## Overview

This pull request introduces several updates to the `skale.py` repository:
1. Enhances the `Linker` contract wrapper with role management methods.
2. Refactors address type hinting across the codebase for improved correctness.
3. Updates the `helper-scripts` submodule to the latest version.

## Key Changes

* **Linker Role Management:**
    * Added `linker_role()`: Retrieves the `LINKER_ROLE` constant.
    * Added `has_role(role, address)`: Checks if an address holds a specific role.
    * Added `grant_role(role, address)`: Grants a specified role to an address (transaction method).
* **Address Typing Refactor:**
    * Replaced incorrect `int` type hints for addresses with the standard `eth_typing.ChecksumAddress` throughout the codebase.
* **Submodule Update:**
    * Updated the `helper-scripts` submodule pointer to its latest develo[ commit/version.

## Rationale

* **Linker Methods:** Provide a direct interface within `skale.py` for managing Linker contract permissions.
* **Typing Refactor:** Improves code quality, clarity, and type safety by using the correct type hint for Ethereum addresses, aligning with `web3.py` and static analysis best practices.
* **Submodule Update:** Incorporates the latest changes, fixes, or features from the `helper-scripts` repository.

## Impact

* The Linker methods are non-breaking, additive changes.
* The address typing refactor enhances code correctness and maintainability; it should not cause runtime issues if addresses were already being passed as checksummed strings, but improves static analysis capabilities.
* The impact of the `helper-scripts` update depends on the specific changes included in its latest version.