### PR TITLE
Update error handling in get endpoint

### DIFF
--- a/skale/utils/web3_utils.py
+++ b/skale/utils/web3_utils.py
@@ -99,7 +99,7 @@ def _get_connected_endpoint(endpoints: list[str]) -> str:
         except ProviderConnectionError as e:
             logger.warning(f'Could not connect to {url}. Error: {e}. Trying next endpoint...')
             time.sleep(2)
-    raise ProviderConnectionError('Could not connect to any RPC endpoints.')
+    raise ProviderConnectionError(f'Could not connect to any RPC endpoints: {endpoints}')
 
 
 def get_receipt(web3: Web3, tx: _Hash32) -> TxReceipt:


### PR DESCRIPTION
This pull request includes a small but important improvement to the error message raised in the `_get_connected_endpoint` function within `skale/utils/web3_utils.py`. The change enhances the clarity of the error message by including the list of endpoints that were attempted.