### PR TITLE
Fix _to_id function in RedisWallet

### DIFF
--- a/skale/wallets/redis_wallet.py
+++ b/skale/wallets/redis_wallet.py
@@ -147,8 +147,8 @@ class RedisWalletAdapter(BaseWallet):
         return Web3.to_bytes(tx_id)
 
     @classmethod
-    def _to_id(cls, raw_id: bytes) -> HexStr:
-        return Web3.to_hex(raw_id)
+    def _to_id(cls, raw_id: bytes) -> str:
+        return raw_id.decode('utf-8')
 
     def sign_and_send(
         self,
@@ -156,7 +156,7 @@ class RedisWalletAdapter(BaseWallet):
         multiplier: Optional[float] = None,
         priority: Optional[int] = None,
         method: Optional[str] = None,
-    ) -> HexStr:
+    ):
         priority = priority or config.DEFAULT_PRIORITY
         try:
             logger.info('Sending %s to redis pool, method: %s', tx, method)


### PR DESCRIPTION
This pull request includes a change to the `skale/wallets/redis_wallet.py` file. The `_to_id` method's return type has been updated to return a UTF-8 decoded string instead of a hexadecimal string. Additionally, the `sign_and_send` method's return type annotation has been removed.

Key changes:

* Updated `_to_id` method to return a UTF-8 decoded string instead of a hexadecimal string, improving readability and compatibility with downstream processes. (`[skale/wallets/redis_wallet.pyL150-R159](diffhunk://#diff-3be6d6947556af62c15f1ea38e2de369ba4283df306deeafea31a308e434ffb7L150-R159)`)
* Removed the return type annotation from the `sign_and_send` method, possibly to allow greater flexibility in return values. (`[skale/wallets/redis_wallet.pyL150-R159](diffhunk://#diff-3be6d6947556af62c15f1ea38e2de369ba4283df306deeafea31a308e434ffb7L150-R159)`)