### PR TITLE
Add fixes to redis wallet

### DIFF
--- a/skale/wallets/redis_wallet.py
+++ b/skale/wallets/redis_wallet.py
@@ -28,8 +28,7 @@ from typing import Optional, Tuple, TypedDict
 from eth_account.datastructures import SignedMessage, SignedTransaction
 from eth_typing import ChecksumAddress, HexStr
 from redis import Redis
-from web3 import Web3
-from web3.types import _Hash32, TxParams, TxReceipt
+from web3.types import TxParams, TxReceipt
 
 import skale.config as config
 from skale.transactions.exceptions import (
@@ -76,7 +75,29 @@ class TxRecordStatus(str, Enum):
 
 TxRecord = TypedDict(
     'TxRecord',
-    {'status': TxRecordStatus, 'tx_hash': HexStr},
+    {
+        'status': TxRecordStatus,
+        'score': int,
+        'multiplier': Optional[float],
+        'tx_hash': HexStr,
+        'tx_id': str | None,
+        'method': Optional[str],
+        'value': int,
+        'chainId': int | None,
+        'gas': int | None,
+        'gasPrice': int | None,
+        'from': ChecksumAddress,
+        'to': ChecksumAddress,
+        'maxFeePerGas': int | None,
+        'maxPriorityFeePerGas': int | None,
+        'hashes': list | None,
+        'attempts': int | None,
+        'source': str | None,
+        'nonce': int | None,
+        'data': dict | None,
+        'meta': dict | None,
+        'sent_ts': int | None,
+    },
 )
 
 
@@ -141,10 +162,8 @@ class RedisWalletAdapter(BaseWallet):
         return tx_id, record
 
     @classmethod
-    def _to_raw_id(cls, tx_id: _Hash32) -> bytes:
-        if isinstance(tx_id, str):
-            return Web3.to_bytes(hexstr=tx_id)
-        return Web3.to_bytes(tx_id)
+    def _to_raw_id(cls, tx_id: str) -> bytes:
+        return tx_id.encode('utf-8')
 
     @classmethod
     def _to_id(cls, raw_id: bytes) -> str:
@@ -175,20 +194,44 @@ class RedisWalletAdapter(BaseWallet):
             logger.exception(f'Sending {tx} with redis wallet errored')
             raise RedisWalletNotSentError(err)
 
-    def get_status(self, tx_id: _Hash32) -> str:
+    def get_status(self, tx_id: str) -> str:
         return self.get_record(tx_id)['status']
 
-    def get_record(self, tx_id: _Hash32) -> TxRecord:
+    def get_record(self, tx_id: str) -> TxRecord:
         rid = self._to_raw_id(tx_id)
         response = self.rs.get(rid)
         if isinstance(response, bytes):
             parsed_json = json.loads(response.decode('utf-8'))
-            return TxRecord({'status': parsed_json['status'], 'tx_hash': parsed_json['tx_hash']})
+            return TxRecord(
+                {
+                    'tx_id': parsed_json.get('tx_id'),
+                    'status': parsed_json['status'],
+                    'score': parsed_json['score'],
+                    'multiplier': parsed_json.get('multiplier'),
+                    'tx_hash': parsed_json['tx_hash'],
+                    'method': parsed_json.get('method'),
+                    'value': parsed_json['value'],
+                    'chainId': parsed_json.get('chainId'),
+                    'gas': parsed_json.get('gas'),
+                    'gasPrice': parsed_json.get('gasPrice'),
+                    'from': parsed_json['from'],
+                    'to': parsed_json['to'],
+                    'maxFeePerGas': parsed_json.get('maxFeePerGas'),
+                    'maxPriorityFeePerGas': parsed_json.get('maxPriorityFeePerGas'),
+                    'hashes': parsed_json.get('hashes'),
+                    'attempts': parsed_json.get('attempts'),
+                    'source': parsed_json.get('source'),
+                    'nonce': parsed_json.get('nonce'),
+                    'data': parsed_json.get('data'),
+                    'meta': parsed_json.get('meta'),
+                    'sent_ts': parsed_json.get('sent_ts'),
+                }
+            )
         raise ValueError('Unknown value was returned from get() call', response)
 
     def wait(
         self,
-        tx_id: _Hash32,
+        tx_id,
         blocks_to_wait: int = DEFAULT_BLOCKS_TO_WAIT,
         timeout: int = MAX_WAITING_TIME,
     ) -> TxReceipt:

--- a/tests/utils/web3_utils_test.py
+++ b/tests/utils/web3_utils_test.py
@@ -6,7 +6,7 @@ import pytest
 from unittest import mock
 from freezegun import freeze_time
 
-from web3.exceptions import StaleBlockchain
+from web3.exceptions import StaleBlockchain, ProviderConnectionError
 from skale.utils.web3_utils import get_endpoint
 import skale.config as config
 
@@ -65,7 +65,7 @@ def test_get_endpoint():
         endpoint = get_endpoint('http://localhost:1111')
         assert endpoint == 'http://localhost:1111'
 
-    with pytest.raises(ConnectionError):
+    with pytest.raises(ProviderConnectionError):
         get_endpoint(['invalid_endpoint'])
 
     endpoint = get_endpoint(['http://localhost:1111', ENDPOINT])

--- a/tests/wallets/redis_adapter_test.py
+++ b/tests/wallets/redis_adapter_test.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from unittest import mock
 import pytest
 from freezegun import freeze_time
-from web3 import Web3
 
 from skale.wallets.redis_wallet import (
     RedisWalletNotSentError,
@@ -68,8 +67,8 @@ def test_sign_and_send(rdp):
         'nonce': 1,
         'chainId': 1,
     }
-    tx_id = Web3.to_bytes(hexstr=rdp.sign_and_send(tx, multiplier=2, priority=5))
-    assert tx_id.startswith(b'tx-') and len(tx_id) == 19
+    tx_id = rdp.sign_and_send(tx, multiplier=2, priority=5)
+    assert str(tx_id).startswith('tx-') and len(tx_id) == 19
 
     rdp.rs.pipeline = mock.Mock(side_effect=RedisTestError('rtest'))
     with pytest.raises(RedisWalletNotSentError):


### PR DESCRIPTION
This pull request refactors the `RedisWallet` class in `skale/wallets/redis_wallet.py` to enhance type safety, improve data structure extensibility, and simplify handling of transaction IDs. The most significant changes include replacing `_Hash32` with `str` for transaction IDs, expanding the `TxRecord` structure, and updating methods to align with the new `TxRecord` format.

### Type Safety and Transaction ID Handling:
* Replaced `_Hash32` with `str` for transaction IDs across methods, simplifying encoding and decoding logic. (`[[1]](diffhunk://#diff-3be6d6947556af62c15f1ea38e2de369ba4283df306deeafea31a308e434ffb7L144-R166)`, `[[2]](diffhunk://#diff-3be6d6947556af62c15f1ea38e2de369ba4283df306deeafea31a308e434ffb7L178-R234)`)

### Data Structure Enhancements:
* Expanded the `TxRecord` structure to include additional fields such as `score`, `multiplier`, `method`, `value`, `chainId`, and more, enabling richer metadata for transactions. (`[skale/wallets/redis_wallet.pyL79-R100](diffhunk://#diff-3be6d6947556af62c15f1ea38e2de369ba4283df306deeafea31a308e434ffb7L79-R100)`)
* Updated the `get_record` method to construct `TxRecord` objects with the new fields, ensuring compatibility with the expanded structure. (`[skale/wallets/redis_wallet.pyL178-R234](diffhunk://#diff-3be6d6947556af62c15f1ea38e2de369ba4283df306deeafea31a308e434ffb7L178-R234)`)

### Dependency Cleanup:
* Removed unused `Web3` import, reducing unnecessary dependencies. (`[skale/wallets/redis_wallet.pyL31-R31](diffhunk://#diff-3be6d6947556af62c15f1ea38e2de369ba4283df306deeafea31a308e434ffb7L31-R31)`)