### PR TITLE
Update committeee group to include committee data

### DIFF
--- a/skale/mirage_config/committee_nodes.py
+++ b/skale/mirage_config/committee_nodes.py
@@ -25,19 +25,23 @@ def get_nodes_from_last_two_committees(mirage: MirageManager) -> list[CommitteeG
         ts_a = 0
     else:
         committee_a_index: CommitteeIndex = CommitteeIndex(latest_committee_index - 1)
-        ts_a = mirage.committee.get_committee(CommitteeIndex(committee_a_index)).starting_timestamp
-    committee_a_nodes_data: dict = {
+        committee_a = mirage.committee.get_committee(CommitteeIndex(committee_a_index))
+        ts_a = committee_a.starting_timestamp
+    committee_a_nodes_data: CommitteeGroup = {
         'index': committee_a_index,
-        'ts': ts_a,
+        'ts': ts_a,  # todod: remove, use from committee structure
         'group': get_committee_nodes(mirage, committee_a_index),
+        'committee': committee_a,
     }
 
     committee_b_index = latest_committee_index
-    ts_b = mirage.committee.get_committee(CommitteeIndex(committee_b_index)).starting_timestamp
+
+    committee_b = mirage.committee.get_committee(CommitteeIndex(committee_b_index))
     committee_b_nodes_data: CommitteeGroup = {
         'index': committee_b_index,
-        'ts': ts_b,
+        'ts': committee_b.starting_timestamp,  # todod: remove, use from committee structure
         'group': get_committee_nodes(mirage, committee_b_index),
+        'committee': mirage.committee.get_committee(committee_b_index),
     }
 
     committee_nodes_data = [committee_a_nodes_data, committee_b_nodes_data]

--- a/skale/types/committee.py
+++ b/skale/types/committee.py
@@ -43,5 +43,6 @@ CommitteeGroup = TypedDict(
         'ts': TimeStamp,
         'index': CommitteeIndex,
         'group': List[MirageNode],
+        'committee': Committee,
     },
 )


### PR DESCRIPTION
This pull request updates the handling of committee data in the `skale` module by introducing a new `committee` field to the data structures and refactoring how committee timestamps are accessed. These changes aim to improve code clarity and reduce redundancy.

### Changes to committee data handling:

* [`skale/mirage_config/committee_nodes.py`](diffhunk://#diff-c0fb0ffab7752632dadb4b5137266e6b680817ba6da1ccc38d8fe9cdf126570dL28-R44): Refactored the `get_nodes_from_last_two_committees` function to include the `committee` object directly in the `CommitteeGroup` dictionary for both committees. This eliminates redundant calls to retrieve committee data and prepares for future removal of the `ts` field.

* [`skale/types/committee.py`](diffhunk://#diff-4759e52c986f2eea83756caf5f56da912c115f502f553477ff061d3a6290501fR46): Added a new `committee` field to the `CommitteeGroup` type definition to reflect the inclusion of the `committee` object in the data structure.