### PR TITLE
Add heartbeat functions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       ENDPOINT: "http://127.0.0.1:8545"
       MANAGER_TAG: "1.12.0-develop.21"
       ALLOCATOR_TAG: "2.2.2-develop.0"
-      MIRAGE_TAG: "0.0.1-develop.21"
+      MIRAGE_TAG: "0.0.1-develop.24"
       MINING_INTERVAL: 10
     steps:
       - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import (
 
 extras_require = {
     'linter': [
-        'ruff==0.9.10',
+        'ruff==0.12.2',
         'isort>=4.2.15,<5.4.3',
         'importlib-metadata<5.0',
     ],
@@ -39,13 +39,12 @@ setup(
     url='https://github.com/skalenetwork/skale.py',
     include_package_data=True,
     install_requires=[
-        'asyncio==3.4.3',
         'pyyaml==6.0',
-        'redis==5.0.3',
+        'redis==6.2.0',
         'sgx.py==0.10dev0',
-        'skale-contracts==1.1.0a0',
-        'typing-extensions==4.9.0',
-        'web3==7.10.0',
+        'skale-contracts==2.0.0a3',
+        'typing-extensions==4.14.1',
+        'web3==7.12.0',
     ],
     python_requires='>=3.11,<4',
     extras_require=extras_require,

--- a/skale/contracts/mirage/status.py
+++ b/skale/contracts/mirage/status.py
@@ -20,9 +20,16 @@
 from skale.contracts.base_contract import BaseContract
 from skale.contracts.base_contract import transaction_method
 from skale.types.node import NodeId
+from skale.types.committee import Timestamp
 
 
 class Status(BaseContract):
+    def last_heartbeat_timestamp(self, node_id: NodeId) -> Timestamp:
+        return self.contract.functions.lastHeartbeatTimestamp(node_id).call()
+
+    def heartbeat_interval(self) -> int:
+        return self.contract.functions.heartbeatInterval().call()
+
     def is_healthy(self, node_id: NodeId) -> bool:
         return self.contract.functions.isHealthy(node_id).call()
 

--- a/skale/types/committee.py
+++ b/skale/types/committee.py
@@ -26,7 +26,7 @@ from skale.types.dkg import DkgId, G2Point
 from skale.types.node import MirageNode, NodeId
 
 CommitteeIndex = NewType('CommitteeIndex', int)
-TimeStamp = NewType('TimeStamp', int)
+Timestamp = NewType('Timestamp', int)
 
 
 @dataclass
@@ -34,13 +34,13 @@ class Committee:
     node_ids: List[NodeId]
     dkg_id: DkgId
     common_public_key: G2Point
-    starting_timestamp: TimeStamp
+    starting_timestamp: Timestamp
 
 
 CommitteeGroup = TypedDict(
     'CommitteeGroup',
     {
-        'ts': TimeStamp,
+        'ts': Timestamp,
         'index': CommitteeIndex,
         'group': List[MirageNode],
         'committee': Committee,


### PR DESCRIPTION
This pull request includes updates to dependencies, naming consistency improvements, and new functionality for contract interaction in the `skale` project. The most important changes involve version updates for key dependencies, the addition of new contract methods, and a consistent renaming of the `TimeStamp` type to `Timestamp`.

### Dependency Updates:
* Updated the `ruff` linter dependency from `0.9.10` to `0.12.2` in `setup.py`.
* Updated several core dependencies in `setup.py`, including:
  - `redis` from `5.0.3` to `6.2.0`
  - `skale-contracts` from `1.1.0a0` to `2.0.0a3`
  - `typing-extensions` from `4.9.0` to `4.14.1`
  - `web3` from `7.10.0` to `7.12.0`

### New Contract Methods:
* Added two new methods in `skale/contracts/mirage/status.py` for interacting with contract functions:
  - `last_heartbeat_timestamp`, which retrieves the last heartbeat timestamp for a given node.
  - `heartbeat_interval`, which retrieves the interval for heartbeats.

### Naming Consistency:
* Renamed the `TimeStamp` type to `Timestamp` in `skale/types/committee.py` to ensure consistent naming across the codebase. This change affects type definitions and references in the `Committee` class and related structures.

### Workflow Update:
* Updated the `MIRAGE_TAG` in `.github/workflows/test.yml` from `0.0.1-develop.21` to `0.0.1-develop.24` to use a newer version in the CI pipeline.