### PR TITLE
Add rng funcs

### DIFF
--- a/skale/contracts/fair/committee.py
+++ b/skale/contracts/fair/committee.py
@@ -51,6 +51,17 @@ class Committee(BaseContract):
     def last_committee_index(self) -> CommitteeIndex:
         return CommitteeIndex(self.contract.functions.lastCommitteeIndex().call())
 
+    def skale_rng(self) -> ChecksumAddress:
+        return self.contract.functions.skaleRng().call()
+
+    @transaction_method
+    def set_rng(self, address: ChecksumAddress):
+        return self.contract.functions.setRNG(address)
+
+    @transaction_method
+    def disableRNG(self):
+        return self.contract.functions.disableRNG()
+
     @transaction_method
     def select(self):
         return self.contract.functions.select()

--- a/skale/contracts/fair/staking.py
+++ b/skale/contracts/fair/staking.py
@@ -32,7 +32,9 @@ class Staking(BaseContract):
         return self.contract.functions.getStakedAmount().call()
 
     def get_staked_to_node_amount(self, node: NodeId) -> int:
-        return self.contract.functions.getStakedToNodeAmount(node).call()
+        return self.contract.functions.getStakedToNodeAmount(node).call(
+            {'from': self.skale.wallet.address}
+        )
 
     def get_staked_nodes(self) -> List[NodeId]:
         return self.contract.functions.getStakedNodes().call()

--- a/skale/fair_config/committee_history.py
+++ b/skale/fair_config/committee_history.py
@@ -38,9 +38,7 @@ def unpack_bls_public_key(bls_public_key: G2Point) -> dict[str, str]:
     }
 
 
-def committee_data_to_historical_representation(
-    fair: FairManager, committee: Committee
-) -> dict:
+def committee_data_to_historical_representation(fair: FairManager, committee: Committee) -> dict:
     bls_public_key = committee.common_public_key
     node_ids = committee.node_ids
     nodes = {}
@@ -58,7 +56,7 @@ def committee_data_to_historical_representation(
 
 
 def generate_committee_history(fair: FairManager) -> dict:
-    latest_committee_index: int = fair.committee.get_active_committee_index()
+    latest_committee_index: int = fair.committee.last_committee_index()
     committees = {}
 
     current_finish_ts = None

--- a/skale/fair_config/committee_nodes.py
+++ b/skale/fair_config/committee_nodes.py
@@ -19,7 +19,7 @@ def get_nodes_from_last_two_committees(fair: FairManager) -> list[CommitteeGroup
     as first and second committee with first timestamp equal to 0
     """
 
-    latest_committee_index: int = fair.committee.get_active_committee_index()
+    latest_committee_index: int = fair.committee.last_committee_index()
     if latest_committee_index == 0:
         committee_a_index: CommitteeIndex = CommitteeIndex(0)
         committee_a = fair.committee.get_committee(CommitteeIndex(0))


### PR DESCRIPTION
This pull request introduces new functionality for managing RNG (Random Number Generator) in the `committee.py` contract and modifies the staking logic in `staking.py` to include transaction context. Below is a summary of the most important changes:

### RNG Management Enhancements:
* [`skale/contracts/fair/committee.py`](diffhunk://#diff-0f0a8fc4b85298593546cbe3396233e07a16b1be1ce58be5a1beae732d70566cR54-R64): Added methods `skale_rng`, `set_rng`, and `disableRNG` to retrieve, set, and disable the RNG address, respectively. These changes enable more control over RNG configuration.

### Staking Logic Updates:
* [`skale/contracts/fair/staking.py`](diffhunk://#diff-98590911185c2dcc4229aeecc83741e42e5eee89f651b137ba2cf84c03192e57L35-R37): Updated the `get_staked_to_node_amount` method to include the transaction context (`{'from': self.skale.wallet.address}`), ensuring that the correct wallet address is used for the call.