### PR TITLE
Add delete node command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       ENDPOINT: "http://127.0.0.1:8545"
       MANAGER_TAG: "1.12.0-develop.21"
       ALLOCATOR_TAG: "2.2.2-develop.0"
-      FAIR_TAG: "0.0.1-develop.31"
+      FAIR_TAG: "0.0.1-develop.39"
       MINING_INTERVAL: 10
     steps:
       - uses: actions/checkout@v4

--- a/skale/contracts/fair/nodes.py
+++ b/skale/contracts/fair/nodes.py
@@ -100,3 +100,7 @@ class Nodes(BaseContract):
     @transaction_method
     def set_committee(self, committee_address: ChecksumAddress):
         return self.contract.functions.setCommittee(committee_address)
+
+    @transaction_method
+    def delete_node(self, node_id: NodeId):
+        return self.contract.functions.deleteNode(node_id)

--- a/skale/utils/contracts_provision/fair.py
+++ b/skale/utils/contracts_provision/fair.py
@@ -26,7 +26,6 @@ from skale import SkaleManager
 from skale.types.schain import SchainName
 from skale.utils.account_tools import send_eth
 from skale.utils.contracts_provision.main import (
-    DEFAULT_DOMAIN_NAME,
     add_test2_schain_type,
     add_test4_schain_type,
     add_test_permissions,
@@ -85,7 +84,7 @@ def register_node(skale):
         port=port,
         name=name,
         public_ip=public_ip,
-        domain_name=DEFAULT_DOMAIN_NAME,
+        domain_name=f'{name}.com',
         wait_for=True,
     )
     node_id = skale.nodes.node_name_to_index(name)

--- a/tests/fair/nodes_test.py
+++ b/tests/fair/nodes_test.py
@@ -243,3 +243,22 @@ def test_decode_public_key(fair):
     assert isinstance(decoded, str)
     assert decoded.startswith('0x')
     assert len(decoded) == 18
+
+
+@pytest.mark.parametrize('number_of_nodes', [1])
+def test_delete_node(fair, fair_passive_nodes):
+    main_wallet = fair.wallet
+
+    node_id = fair.nodes.get_passive_node_ids_for_address(fair_passive_nodes[0].address)[0]
+
+    passive_node_ids_before = fair.nodes.get_passive_node_ids()
+    assert node_id in passive_node_ids_before
+
+    fair.wallet = fair_passive_nodes[0]
+    fair.nodes.delete_node(node_id)
+
+    passive_node_ids_after = fair.nodes.get_passive_node_ids()
+    assert node_id not in passive_node_ids_after
+    assert len(passive_node_ids_after) == len(passive_node_ids_before) - 1
+
+    fair.wallet = main_wallet


### PR DESCRIPTION
This pull request introduces updates to the FAIR module, including enhancements to node management, test coverage, and configuration adjustments. The most significant changes include the addition of a `delete_node` method, updates to the `register_node` function to use dynamic domain names, and the introduction of a new test for node deletion.

### Node management enhancements:
* [`skale/contracts/fair/nodes.py`](diffhunk://#diff-d1a9cbf7acd18c8619adde227cbce4ccb0d37bc1982bb11e09c2cd0c943e6fd7R103-R106): Added a new `delete_node` method to enable the removal of nodes by their `node_id`.

### Test coverage improvements:
* [`tests/fair/nodes_test.py`](diffhunk://#diff-bd432ba3b6e3be77e61c4c1c2c2f6a3687d95fb74018836d26880dfe0cb45947R246-R264): Added a new test, `test_delete_node`, to verify the functionality of the `delete_node` method, ensuring that nodes are properly removed and the passive node list is updated accordingly.

### Configuration updates:
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L16-R16): Updated the `FAIR_TAG` in the workflow configuration from `0.0.1-develop.31` to `0.0.1-develop.39` to use the latest version.

### Code simplifications:
* [`skale/utils/contracts_provision/fair.py`](diffhunk://#diff-d13f93de9d4ee5eb236de2e59329181d47757f54166fe2161c380310f52cec6fL29): Removed the unused `DEFAULT_DOMAIN_NAME` import and updated the `register_node` function to dynamically generate domain names using the node's name. [[1]](diffhunk://#diff-d13f93de9d4ee5eb236de2e59329181d47757f54166fe2161c380310f52cec6fL29) [[2]](diffhunk://#diff-d13f93de9d4ee5eb236de2e59329181d47757f54166fe2161c380310f52cec6fL88-R87)