### PR TITLE
Add staking contract address to CommitteeGroup

### DIFF
--- a/skale/fair_config/committee_nodes.py
+++ b/skale/fair_config/committee_nodes.py
@@ -1,3 +1,5 @@
+from eth_utils.address import to_checksum_address
+
 from skale.fair_manager import FairManager
 from skale.types.committee import CommitteeGroup, CommitteeIndex
 from skale.types.node import FairNode, FairNodeWithRewardWalletAddress, NodeId
@@ -45,19 +47,30 @@ def get_nodes_from_last_two_committees(fair: FairManager) -> list[CommitteeGroup
         committee_a_index: CommitteeIndex = CommitteeIndex(latest_committee_index - 1)
         committee_a = fair.committee.get_committee(CommitteeIndex(committee_a_index))
         ts_a = committee_a.starting_timestamp
+
+    staking_contract_address = to_checksum_address(ZERO_ADDRESS)
+    if committee_a_index > 0:
+        staking_contract_address = to_checksum_address(fair.staking.contract.address)
+
     committee_a_nodes_data: CommitteeGroup = {
         'index': committee_a_index,
         'ts': ts_a,  # todod: remove, use from committee structure
+        'staking_contract_address': staking_contract_address,
         'group': get_committee_nodes(fair, committee_a_index),
         'committee': committee_a,
     }
 
     committee_b_index = latest_committee_index
 
+    staking_contract_address = to_checksum_address(ZERO_ADDRESS)
+    if committee_b_index > 0:
+        staking_contract_address = to_checksum_address(fair.staking.contract.address)
+
     committee_b = fair.committee.get_committee(CommitteeIndex(committee_b_index))
     committee_b_nodes_data: CommitteeGroup = {
         'index': committee_b_index,
         'ts': committee_b.starting_timestamp,  # todod: remove, use from committee structure
+        'staking_contract_address': staking_contract_address,
         'group': get_committee_nodes(fair, committee_b_index),
         'committee': fair.committee.get_committee(committee_b_index),
     }

--- a/skale/types/committee.py
+++ b/skale/types/committee.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List, NewType, TypedDict
 
+from skale_contracts.instance import ChecksumAddress
+
 from skale.types.dkg import DkgId, G2Point
 from skale.types.node import FairNodeWithRewardWalletAddress, NodeId
 
@@ -42,6 +44,7 @@ CommitteeGroup = TypedDict(
     {
         'ts': Timestamp,
         'index': CommitteeIndex,
+        'staking_contract_address': ChecksumAddress,
         'group': List[FairNodeWithRewardWalletAddress],
         'committee': Committee,
     },

--- a/tests/fair/fair_config_test.py
+++ b/tests/fair/fair_config_test.py
@@ -68,6 +68,8 @@ def test_get_nodes_from_last_two_committees_first_committee():
     assert result[0]['ts'] == 0
     assert result[1]['index'] == 0
     assert result[1]['ts'] == 1500
+    assert result[0]['staking_contract_address'] == '0x0000000000000000000000000000000000000000'
+    assert result[1]['staking_contract_address'] == '0x0000000000000000000000000000000000000000'
 
 
 def test_get_nodes_from_last_two_committees_multiple_committees():
@@ -90,6 +92,7 @@ def test_get_nodes_from_last_two_committees_multiple_committees():
 
     fair.committee.get_committee.side_effect = get_committee_side_effect
     fair.web3.to_checksum_address.return_value = '0x0000000000000000000000000000000000000000'
+    fair.staking.contract.address = '0x7777777777777777777777777777777777777777'
 
     nodes = {}
     for node_id in node_ids_1 + node_ids_2:
@@ -104,6 +107,8 @@ def test_get_nodes_from_last_two_committees_multiple_committees():
     assert result[0]['ts'] == 1000
     assert result[1]['index'] == 2
     assert result[1]['ts'] == 2000
+    assert result[0]['staking_contract_address'] == '0x7777777777777777777777777777777777777777'
+    assert result[1]['staking_contract_address'] == '0x7777777777777777777777777777777777777777'
 
 
 def test_get_nodes_from_last_two_committees_structure():


### PR DESCRIPTION
This pull request adds support for including the staking contract address in the committee group data structure returned by `get_nodes_from_last_two_committees`. The changes ensure that each committee group now contains a `staking_contract_address` field, and updates the type definitions and tests accordingly.

**Committee group data structure enhancements:**
* Added a `staking_contract_address` field to the `CommitteeGroup` type, ensuring that committee group dictionaries now include the staking contract address as a `ChecksumAddress`. [[1]](diffhunk://#diff-4759e52c986f2eea83756caf5f56da912c115f502f553477ff061d3a6290501fR25-R26) [[2]](diffhunk://#diff-4759e52c986f2eea83756caf5f56da912c115f502f553477ff061d3a6290501fR47)
* Updated `get_nodes_from_last_two_committees` in `committee_nodes.py` to populate the new `staking_contract_address` field for both committees, using either the staking contract address or zero address depending on committee index. [[1]](diffhunk://#diff-7202ef73f299b1486a87691fd40f0ceb8a970815b4d69954742a77a96ebc8027R1-R2) [[2]](diffhunk://#diff-7202ef73f299b1486a87691fd40f0ceb8a970815b4d69954742a77a96ebc8027R50-R73)

**Test updates:**
* Extended existing tests to assert the correct value of the new `staking_contract_address` field for various committee configurations. [[1]](diffhunk://#diff-4bf5cbca5257cd7a7e1c361d7a2a26d657a7cbeda983e90d61a60af64ff4049aR71-R72) [[2]](diffhunk://#diff-4bf5cbca5257cd7a7e1c361d7a2a26d657a7cbeda983e90d61a60af64ff4049aR95) [[3]](diffhunk://#diff-4bf5cbca5257cd7a7e1c361d7a2a26d657a7cbeda983e90d61a60af64ff4049aR110-R111)
