### PR TITLE
Update fair manager to the latest version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       ENDPOINT: "http://127.0.0.1:8545"
       MANAGER_TAG: "1.12.0-develop.21"
       ALLOCATOR_TAG: "2.2.2-develop.0"
-      FAIR_TAG: "0.0.1-develop.52"
+      FAIR_TAG: "0.0.1-develop.53"
       MINING_INTERVAL: 10
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes a minor update to the GitHub Actions workflow configuration. The version tag for the `FAIR` service has been incremented from `0.0.1-develop.52` to `0.0.1-develop.53` to use the latest development version in CI runs.