### PR TITLE
Update fair manager tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       ENDPOINT: "http://127.0.0.1:8545"
       MANAGER_TAG: "1.12.0-develop.21"
       ALLOCATOR_TAG: "2.2.2-develop.0"
-      FAIR_TAG: "0.0.1-develop.53"
+      FAIR_TAG: "0.0.1-beta.1"
       MINING_INTERVAL: 10
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the `FAIR_TAG` environment variable in the GitHub Actions workflow configuration. The tag is changed from a development version to a beta release.

* Workflow configuration update:
  * [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L16-R16): Changed the `FAIR_TAG` value from `"0.0.1-develop.53"` to `"0.0.1-beta.1"` to use the beta release of the FAIR component.