### PR TITLE
Add reward wallet address to historic node groups

### DIFF
--- a/skale/fair_config/committee_history.py
+++ b/skale/fair_config/committee_history.py
@@ -22,6 +22,7 @@ import logging
 from skale import FairManager
 from skale.types.committee import Committee, CommitteeIndex
 from skale.types.dkg import G2Point
+from skale.utils.web3_utils import public_key_to_address
 
 logger = logging.getLogger(__name__)
 
@@ -47,8 +48,11 @@ def committee_data_to_historical_representation(fair: FairManager, committee: Co
     for index_in_committee, node_id in enumerate(node_ids):
         public_key = fair.nodes.get_public_key(node_id)
         if node_id in initial_committee.node_ids:
-            reward_wallet_address = fair.nodes.get(node_id).address
+            # If node is in initial committee using owner key.
+            # Using public_key since it is available for removed nodes
+            reward_wallet_address = public_key_to_address(public_key)
         else:
+            # For other nodes using reward wallet address
             reward_wallet_address = fair.staking.get_reward_wallet(node_id)
         nodes[node_id] = (index_in_committee, node_id, public_key, reward_wallet_address)
     committee_data = {

--- a/skale/fair_config/committee_history.py
+++ b/skale/fair_config/committee_history.py
@@ -41,13 +41,16 @@ def committee_data_to_historical_representation(fair: FairManager, committee: Co
     bls_public_key = committee.common_public_key
     node_ids = committee.node_ids
     nodes = {}
+    initial_committee_index: CommitteeIndex = CommitteeIndex(0)
+    initial_committee = fair.committee.get_committee(initial_committee_index)
+
     for index_in_committee, node_id in enumerate(node_ids):
         public_key = fair.nodes.get_public_key(node_id)
-        nodes[node_id] = (
-            index_in_committee,
-            node_id,
-            public_key,
-        )
+        if node_id in initial_committee.node_ids:
+            reward_wallet_address = fair.nodes.get(node_id).address
+        else:
+            reward_wallet_address = fair.staking.get_reward_wallet(node_id)
+        nodes[node_id] = (index_in_committee, node_id, public_key, reward_wallet_address)
     committee_data = {
         'rotation': None,
         'nodes': nodes,


### PR DESCRIPTION
This pull request updates the `committee_data_to_historical_representation` function in `committee_history.py` to enhance how node data is represented, specifically by including the reward wallet address for each node. The reward wallet address is determined differently depending on whether the node is part of the initial committee.

Key changes to node data representation:

* The `nodes` dictionary now includes the `reward_wallet_address` for each node, in addition to its previous attributes.
* The reward wallet address is set to the node's own address if it belongs to the initial committee, or retrieved via `fair.staking.get_reward_wallet(node_id)` otherwise.
* The initial committee is determined by fetching committee index 0 with `fair.committee.get_committee(initial_committee_index)`.