### PR TITLE
Update staking functions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       ENDPOINT: "http://127.0.0.1:8545"
       MANAGER_TAG: "1.12.0-develop.21"
       ALLOCATOR_TAG: "2.2.2-develop.0"
-      FAIR_TAG: "0.0.1-develop.53"
+      FAIR_TAG: "0.0.1-develop.71"
       MINING_INTERVAL: 10
     steps:
       - uses: actions/checkout@v4

--- a/skale/contracts/fair/nodes.py
+++ b/skale/contracts/fair/nodes.py
@@ -53,6 +53,15 @@ class Nodes(BaseContract):
     def active_node_exists(self, node_id: NodeId) -> bool:
         return self.contract.functions.activeNodeExists(node_id).call()
 
+    def passive_node_exists(self, node_id: NodeId) -> bool:
+        return self.contract.functions.passiveNodeExists(node_id).call()
+
+    def get_owner_change_request(self, node_id: NodeId) -> ChecksumAddress:
+        return self.contract.functions.ownerChangeRequests(node_id).call()
+
+    def committee_contract(self) -> ChecksumAddress:
+        return self.contract.functions.committeeContract().call()
+
     def _to_node(self, untyped_node: List[Any]) -> FairNode:
         return FairNode(
             id=untyped_node[0],
@@ -103,6 +112,10 @@ class Nodes(BaseContract):
     @transaction_method
     def delete_node(self, node_id: NodeId):
         return self.contract.functions.deleteNode(node_id)
+
+    @transaction_method
+    def delete_node_by_foundation(self, node_id: NodeId):
+        return self.contract.functions.deleteNodeByFoundation(node_id)
 
     def get_public_key(self, node_id: NodeId) -> HexStr:
         raw_public_key = self.contract.functions.getPublicKey(node_id).call()

--- a/skale/contracts/fair/staking.py
+++ b/skale/contracts/fair/staking.py
@@ -45,7 +45,7 @@ class Staking(BaseContract):
         return self.contract.functions.getDelegatorsToNodeCount(node).call()
 
     def get_staked_amount(self) -> int:
-        return self.contract.functions.getStakedAmount().call()
+        return self.contract.functions.getStakedAmount().call({'from': self.skale.wallet.address})
 
     def get_staked_to_node_amount(self, node: NodeId) -> int:
         return self.contract.functions.getStakedToNodeAmount(node).call(
@@ -53,7 +53,7 @@ class Staking(BaseContract):
         )
 
     def get_staked_nodes(self) -> List[NodeId]:
-        return self.contract.functions.getStakedNodes().call()
+        return self.contract.functions.getStakedNodes().call({'from': self.skale.wallet.address})
 
     def get_earned_fee_amount(self, node: NodeId) -> int:
         return self.contract.functions.getEarnedFeeAmount(node).call()
@@ -67,33 +67,81 @@ class Staking(BaseContract):
     def get_staked_to_node_amount_for(self, node: NodeId, holder: ChecksumAddress) -> int:
         return self.contract.functions.getStakedToNodeAmountFor(node, holder).call()
 
+    def get_exit_requests_count_for(self, user: ChecksumAddress) -> int:
+        return self.contract.functions.getExitRequestsCountFor(user).call()
+
+    def get_my_total_in_exit_queue(self) -> int:
+        return self.contract.functions.getMyTotalInExitQueue().call(
+            {'from': self.skale.wallet.address}
+        )
+
+    def get_my_exit_requests_count(self) -> int:
+        return self.contract.functions.getMyExitRequestsCount().call(
+            {'from': self.skale.wallet.address}
+        )
+
+    def is_within_stake_limit(self, node: NodeId) -> bool:
+        return self.contract.functions.isWithinStakeLimit(node).call()
+
+    def get_exit_request(self, request_id: int):
+        return self.contract.functions.getExitRequest(request_id).call()
+
+    def get_unlocked_exit_request_for(self, user: ChecksumAddress, from_index: int):
+        return self.contract.functions.getUnlockedExitRequestFor(user, from_index).call()
+
+    def get_exit_request_at(self, user: ChecksumAddress, index: int):
+        return self.contract.functions.getExitRequestAt(user, index).call()
+
+    def is_request_unlocked(self, request_id: int) -> bool:
+        return self.contract.functions.isRequestUnlocked(request_id).call()
+
+    def get_retrieving_delay(self) -> int:
+        return self.contract.functions.getRetrievingDelay().call()
+
+    def get_total_in_exit_queue_for(self, user: ChecksumAddress) -> int:
+        return self.contract.functions.getTotalInExitQueueFor(user).call()
+
+    def get_total_in_exit_queue(self) -> int:
+        return self.contract.functions.getTotalInExitQueue().call()
+
+    def get_self_stake_requirement(self) -> int:
+        return self.contract.functions.selfStakeRequirement().call()
+
     @transaction_method
     def stake(self, node: NodeId):
         return self.contract.functions.stake(node)
 
     @transaction_method
-    def retrieve(self, node: NodeId, value: int):
-        return self.contract.functions.retrieve(node, value)
+    def request_retrieve(self, node: NodeId, value: int):
+        return self.contract.functions.requestRetrieve(node, value)
+
+    @transaction_method
+    def request_retrieve_all(self, node: NodeId):
+        return self.contract.functions.requestRetrieveAll(node)
 
     @transaction_method
     def set_fee_rate(self, fee_rate: int):
         return self.contract.functions.setFeeRate(fee_rate)
 
     @transaction_method
-    def claim_fees(self, node: NodeId, amount: int):
-        return self.contract.functions.claimFees(node, amount)
+    def request_fees(self, node: NodeId, amount: int):
+        return self.contract.functions.requestFees(node, amount)
 
     @transaction_method
-    def claim_all_fees(self, node: NodeId):
-        return self.contract.functions.claimAllFees(node)
+    def request_all_fees(self, node: NodeId):
+        return self.contract.functions.requestAllFees(node)
 
     @transaction_method
-    def send_fees(self, to: ChecksumAddress, amount: int):
-        return self.contract.functions.sendFees(to, amount)
+    def request_send_fees(self, to: ChecksumAddress, amount: int):
+        return self.contract.functions.requestSendFees(to, amount)
 
     @transaction_method
-    def send_all_fees(self, to: ChecksumAddress):
-        return self.contract.functions.sendAllFees(to)
+    def request_send_all_fees(self, to: ChecksumAddress):
+        return self.contract.functions.requestSendAllFees(to)
+
+    @transaction_method
+    def claim_request(self, request_id: int):
+        return self.contract.functions.claimRequest(request_id)
 
     @transaction_method
     def disable(self, node: NodeId):
@@ -118,6 +166,14 @@ class Staking(BaseContract):
     @transaction_method
     def set_reward_wallet_reference(self, reward_wallet_reference: ChecksumAddress):
         return self.contract.functions.setRewardWalletReference(reward_wallet_reference)
+
+    @transaction_method
+    def set_self_stake_requirement(self, amount: int):
+        return self.contract.functions.setSelfStakeRequirement(amount)
+
+    @transaction_method
+    def set_retrieving_delay(self, delay: int):
+        return self.contract.functions.setRetrievingDelay(delay)
 
     def get_reward_wallet(self, node: NodeId) -> ChecksumAddress:
         return self.contract.functions.getRewardWallet(node).call()

--- a/skale/contracts/fair/staking.py
+++ b/skale/contracts/fair/staking.py
@@ -104,7 +104,7 @@ class Staking(BaseContract):
     def get_total_in_exit_queue(self) -> int:
         return self.contract.functions.getTotalInExitQueue().call()
 
-    def get_self_stake_requirement(self) -> int:
+    def self_stake_requirement(self) -> int:
         return self.contract.functions.selfStakeRequirement().call()
 
     @transaction_method

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,7 +112,8 @@ def fair_active_nodes(fair, node_wallets):
     for wallet in node_wallets:
         fair.wallet = wallet
         ip, _, port, _ = generate_random_node_data()
-        fair.nodes.register_active(ip=ip, port=port)
+        self_stake_requirement = fair.staking.self_stake_requirement()
+        fair.nodes.register_active(ip=ip, port=port, value=self_stake_requirement)
 
     fair.wallet = main_wallet
     try:

--- a/tests/fair/nodes_test.py
+++ b/tests/fair/nodes_test.py
@@ -33,12 +33,13 @@ def test_register_active_node(fair, node_wallets):
     main_wallet = fair.wallet
     fair.wallet = node_wallets[0]
     ip, _, port, _ = generate_random_node_data()
+    self_stake_requirement = fair.staking.self_stake_requirement()
 
     with pytest.raises(ContractLogicError):
         fair.nodes.get_by_address(fair.wallet.address)
 
     active_node_ids_before = fair.nodes.get_active_node_ids()
-    fair.nodes.register_active(ip=ip, port=port)
+    fair.nodes.register_active(ip=ip, port=port, value=self_stake_requirement)
     active_node_ids_after = fair.nodes.get_active_node_ids()
 
     assert len(active_node_ids_after) == len(active_node_ids_before) + 1
@@ -218,8 +219,9 @@ def test_get_by_address(fair, node_wallets):
     main_wallet = fair.wallet
     fair.wallet = node_wallets[0]
     ip, _, port, _ = generate_random_node_data()
+    self_stake_requirement = fair.staking.self_stake_requirement()
 
-    fair.nodes.register_active(ip=ip, port=port)
+    fair.nodes.register_active(ip=ip, port=port, value=self_stake_requirement)
     node = fair.nodes.get_by_address(fair.wallet.address)
 
     assert node is not None

--- a/tests/fair/nodes_test.py
+++ b/tests/fair/nodes_test.py
@@ -242,6 +242,19 @@ def test_active_node_exists(fair, fair_active_nodes):
     assert fair.nodes.active_node_exists(999) is False
 
 
+@pytest.mark.parametrize('number_of_nodes', [1])
+def test_passive_node_exists_and_owner_request(fair, fair_passive_nodes):
+    node_id = fair.nodes.get_passive_node_ids_for_address(fair_passive_nodes[0].address)[0]
+    assert fair.nodes.passive_node_exists(node_id) is True
+    assert (
+        fair.nodes.get_owner_change_request(node_id) == '0x0000000000000000000000000000000000000000'
+    )
+
+
+def test_committee_contract_accessor(fair):
+    assert fair.nodes.committee_contract() == fair.committee.address
+
+
 def test_decode_public_key(fair):
     raw_public_key = [b'\x12\x34\x56\x78', b'\x9a\xbc\xde\xf0']
     decoded = fair.nodes.decode_public_key(raw_public_key)
@@ -268,3 +281,13 @@ def test_delete_node(fair, fair_passive_nodes):
     assert len(passive_node_ids_after) == len(passive_node_ids_before) - 1
 
     fair.wallet = main_wallet
+
+
+@pytest.mark.parametrize('number_of_nodes', [1])
+def test_delete_node_by_foundation(fair, fair_passive_nodes):
+    node_id = fair.nodes.get_passive_node_ids_for_address(fair_passive_nodes[0].address)[0]
+    before = fair.nodes.get_passive_node_ids()
+    assert node_id in before
+    fair.nodes.delete_node_by_foundation(node_id)
+    after = fair.nodes.get_passive_node_ids()
+    assert node_id not in after

--- a/tests/fair/staking_test.py
+++ b/tests/fair/staking_test.py
@@ -115,12 +115,41 @@ def test_staking_public_methods_present(fair):
     public_attrs = [
         'add_allowed_receiver',
         'remove_allowed_receiver',
-        'send_all_fees',
-        'claim_all_fees',
+        'request_send_all_fees',
+        'request_all_fees',
         'set_fee_rate',
-        'claim_fees',
-        'send_fees',
+        'request_fees',
+        'request_send_fees',
         'get_earned_fee_amount',
+        'request_retrieve',
+        'request_retrieve_all',
+        'claim_request',
+        'set_self_stake_requirement',
+        'set_retrieving_delay',
+        'get_total_in_exit_queue',
+        'get_retrieving_delay',
     ]
     for attr in public_attrs:
         assert hasattr(staking, attr)
+
+
+@pytest.mark.parametrize('number_of_nodes', [1])
+def test_self_stake_requirement_update(fair, fair_active_nodes):
+    staking = fair.staking
+    original = staking.get_self_stake_requirement()
+    assert isinstance(original, int)
+    new_value = original + 1 if original > 0 else 2
+    staking.set_self_stake_requirement(new_value)
+    updated = staking.get_self_stake_requirement()
+    assert updated == new_value
+
+
+@pytest.mark.parametrize('number_of_nodes', [1])
+def test_exit_queue_getters_initial(fair, fair_active_nodes):
+    staking = fair.staking
+    node_id = fair.nodes.get_by_address(fair_active_nodes[0].address).id
+    assert isinstance(staking.get_retrieving_delay(), int)
+    assert isinstance(staking.get_total_in_exit_queue(), int)
+    assert isinstance(staking.is_within_stake_limit(node_id), bool)
+    assert staking.get_my_exit_requests_count() >= 0
+    assert staking.get_my_total_in_exit_queue() >= 0

--- a/tests/fair/staking_test.py
+++ b/tests/fair/staking_test.py
@@ -136,11 +136,11 @@ def test_staking_public_methods_present(fair):
 @pytest.mark.parametrize('number_of_nodes', [1])
 def test_self_stake_requirement_update(fair, fair_active_nodes):
     staking = fair.staking
-    original = staking.get_self_stake_requirement()
+    original = staking.self_stake_requirement()
     assert isinstance(original, int)
     new_value = original + 1 if original > 0 else 2
     staking.set_self_stake_requirement(new_value)
-    updated = staking.get_self_stake_requirement()
+    updated = staking.self_stake_requirement()
     assert updated == new_value
 
 


### PR DESCRIPTION
This pull request introduces several enhancements to the SKALE Fair contracts Python bindings, focusing on expanding staking and node management capabilities, updating transaction methods, and improving test coverage. The most significant changes include the addition of new methods for managing exit queues and stake requirements, the renaming of transactional methods for clarity, and the inclusion of tests for these new functionalities.

**Staking and Exit Queue Enhancements:**

* Added new methods to `skale/contracts/fair/staking.py` for querying and managing exit requests, retrieving delays, stake limits, and self-stake requirements, including `get_exit_requests_count_for`, `get_my_total_in_exit_queue`, `get_my_exit_requests_count`, `is_within_stake_limit`, `get_exit_request`, `get_unlocked_exit_request_for`, `get_exit_request_at`, `is_request_unlocked`, `get_retrieving_delay`, `get_total_in_exit_queue_for`, `get_total_in_exit_queue`, and `get_self_stake_requirement`. Also added transactional methods `set_self_stake_requirement` and `set_retrieving_delay`. [[1]](diffhunk://#diff-98590911185c2dcc4229aeecc83741e42e5eee89f651b137ba2cf84c03192e57R70-R144) [[2]](diffhunk://#diff-98590911185c2dcc4229aeecc83741e42e5eee89f651b137ba2cf84c03192e57R170-R177)

* Updated existing staking-related methods to consistently use the `{'from': self.skale.wallet.address}` parameter for contract calls, ensuring proper context for user-specific queries.

**Transactional Method Renaming and Additions:**

* Renamed staking transactional methods for clarity (e.g., `retrieve` → `request_retrieve`, `claim_fees` → `request_fees`, `send_fees` → `request_send_fees`, etc.), and added new transactional methods for retrieving all, sending all fees, and claiming requests.

**Node Management Improvements:**

* Added new node management methods to `skale/contracts/fair/nodes.py`, including `passive_node_exists`, `get_owner_change_request`, and `committee_contract`, as well as a transactional method `delete_node_by_foundation` for foundation-level node deletion. [[1]](diffhunk://#diff-d1a9cbf7acd18c8619adde227cbce4ccb0d37bc1982bb11e09c2cd0c943e6fd7R56-R64) [[2]](diffhunk://#diff-d1a9cbf7acd18c8619adde227cbce4ccb0d37bc1982bb11e09c2cd0c943e6fd7R116-R119)

**Test Coverage Expansion:**

* Added tests for new node and staking methods in `tests/fair/nodes_test.py` and `tests/fair/staking_test.py`, including passive node existence, owner change requests, committee contract accessor, foundation node deletion, self-stake requirement updates, and exit queue getters. Also updated the public methods presence test to reflect new/renamed methods. [[1]](diffhunk://#diff-bd432ba3b6e3be77e61c4c1c2c2f6a3687d95fb74018836d26880dfe0cb45947R245-R257) [[2]](diffhunk://#diff-bd432ba3b6e3be77e61c4c1c2c2f6a3687d95fb74018836d26880dfe0cb45947R284-R293) [[3]](diffhunk://#diff-c6addac195588647488ffb48be4012e89c78f97334eee07659a43009b0e7a185L118-R155)

**Workflow Update:**

* Updated the `FAIR_TAG` version in `.github/workflows/test.yml` to `0.0.1-develop.71` for CI consistency.