### PR TITLE
Custom gas limit alive

### DIFF
--- a/skale/__init__.py
+++ b/skale/__init__.py
@@ -7,5 +7,6 @@ from skale.skale_manager import SkaleManager
 from skale.skale_allocator import SkaleAllocator
 from skale.skale_ima import SkaleIma
 from skale.fair_manager import FairManager
+from skale.schain_ima import SchainIma
 
-__all__ = ['SkaleManager', 'SkaleAllocator', 'SkaleIma', 'FairManager']
+__all__ = ['SkaleManager', 'SkaleAllocator', 'SkaleIma', 'FairManager', 'SchainIma']

--- a/skale/contracts/fair/status.py
+++ b/skale/contracts/fair/status.py
@@ -58,7 +58,8 @@ class Status(BaseContract):
 
     def calc_alive_gas_limit(self) -> int:
         active_whitelisted_nodes = len(self.active_whitelisted_node_ids())
-        alive_gas_limit = 230000 * math.log(active_whitelisted_nodes + 15) + 420000
+        alive_gas_limit_float = 230000 * math.log(active_whitelisted_nodes + 15) + 420000
+        alive_gas_limit = int(alive_gas_limit_float)
         logger.info(
             'alive_gas_limit: %s, active_whitelisted_nodes: %s',
             alive_gas_limit,

--- a/skale/contracts/fair/status.py
+++ b/skale/contracts/fair/status.py
@@ -52,9 +52,7 @@ class Status(BaseContract):
         return self.contract.functions.isWhitelisted(node_id).call()
 
     def active_whitelisted_node_ids(self) -> list[NodeId]:
-        active_nodes = self.nodes.get_active_node_ids()
-        whitelisted_nodes = self.get_whitelisted_nodes()
-        return [node_id for node_id in active_nodes if node_id in whitelisted_nodes]
+        return list(set(self.nodes.get_active_node_ids()) & set(self.get_whitelisted_nodes()))
 
     def calc_alive_gas_limit(self) -> int:
         active_whitelisted_nodes = len(self.active_whitelisted_node_ids())

--- a/skale/contracts/fair/status.py
+++ b/skale/contracts/fair/status.py
@@ -17,13 +17,25 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
 
+import math
+import logging
+import functools
 from skale.contracts.base_contract import BaseContract
 from skale.contracts.base_contract import transaction_method
+from skale.contracts.fair.nodes import Nodes
 from skale.types.node import NodeId
 from skale.types.committee import Timestamp
 
 
+logger = logging.getLogger(__name__)
+
+
 class Status(BaseContract):
+    @property
+    @functools.lru_cache()
+    def nodes(self) -> 'Nodes':
+        return self.skale.nodes
+
     def last_heartbeat_timestamp(self, node_id: NodeId) -> Timestamp:
         return self.contract.functions.lastHeartbeatTimestamp(node_id).call()
 
@@ -38,6 +50,21 @@ class Status(BaseContract):
 
     def is_whitelisted(self, node_id: NodeId) -> bool:
         return self.contract.functions.isWhitelisted(node_id).call()
+
+    def active_whitelisted_node_ids(self) -> list[NodeId]:
+        active_nodes = self.nodes.get_active_node_ids()
+        whitelisted_nodes = self.get_whitelisted_nodes()
+        return [node_id for node_id in active_nodes if node_id in whitelisted_nodes]
+
+    def calc_alive_gas_limit(self) -> int:
+        active_whitelisted_nodes = len(self.active_whitelisted_node_ids())
+        alive_gas_limit = 230000 * math.log(active_whitelisted_nodes + 15) + 420000
+        logger.info(
+            'alive_gas_limit: %s, active_whitelisted_nodes: %s',
+            alive_gas_limit,
+            active_whitelisted_nodes,
+        )
+        return alive_gas_limit
 
     @transaction_method
     def alive(self):

--- a/tests/fair/status_test.py
+++ b/tests/fair/status_test.py
@@ -50,6 +50,23 @@ def test_node_becomes_enabled_after_whitelist_and_heartbeat(fair, fair_active_no
 
 
 @pytest.mark.parametrize('number_of_nodes', [1])
+def test_calc_alive_gas_limit(fair, fair_active_nodes):
+    node = fair.nodes.get_by_address(fair_active_nodes[0].address)
+    node_id = node.id
+    fair.status.whitelist_node(node_id)
+    fair.staking.stake(node_id, value=10000)
+
+    main_wallet = fair.wallet
+    fair.wallet = fair_active_nodes[0]
+    alive_gas_limit = fair.status.calc_alive_gas_limit()
+    res = fair.status.alive(gas_limit=alive_gas_limit)
+    fair.wallet = main_wallet
+
+    tx = fair.web3.eth.get_transaction(res.tx_hash)
+    assert tx['gas'] == alive_gas_limit
+
+
+@pytest.mark.parametrize('number_of_nodes', [1])
 def test_get_whitelisted_nodes(fair, fair_active_nodes):
     node = fair.nodes.get_by_address(fair_active_nodes[0].address)
     node_id = node.id


### PR DESCRIPTION
This pull request introduces enhancements to node management and gas limit calculation in the SKALE Fair contract, along with corresponding updates to the public API and tests. The main focus is on adding logic to calculate the alive gas limit based on the number of active, whitelisted nodes and exposing new functionality for node status queries.

**Node management and gas limit calculation:**

* Added a new method `active_whitelisted_node_ids` to `Status` for retrieving IDs of nodes that are both active and whitelisted, improving node status handling.
* Implemented `calc_alive_gas_limit` in `Status` to dynamically compute the alive transaction gas limit based on the number of active, whitelisted nodes, including logging for observability.

**API and module updates:**

* Exposed the new `SchainIma` class in the package API by updating the `__all__` list in `skale/__init__.py`.
* Added a cached property `nodes` to the `Status` contract for efficient access to node information.

**Testing improvements:**

* Added a new test `test_calc_alive_gas_limit` to verify that the calculated gas limit matches the value used in the alive transaction, ensuring correctness of the new logic.