### PR TITLE
Allow redis wallet to set custom gas limit

### DIFF
--- a/skale/wallets/redis_wallet.py
+++ b/skale/wallets/redis_wallet.py
@@ -156,8 +156,6 @@ class RedisWalletAdapter(BaseWallet):
             'method': method,
             **tx,
         }
-        # Ensure gas will be restimated in TM
-        params['gas'] = None
         record = json.dumps(params).encode('utf-8')
         return tx_id, record
 

--- a/tests/wallets/redis_adapter_test.py
+++ b/tests/wallets/redis_adapter_test.py
@@ -52,7 +52,7 @@ def test_make_record():
     assert tx_id.startswith(b'tx-') and len(tx_id) == 19
     assert (
         r
-        == b'{"status": "PROPOSED", "score": "51623233060", "multiplier": 2, "tx_hash": null, "method": "createNode", "from": "0x1", "to": "0x2", "value": 1, "gasPrice": 1, "gas": null, "nonce": 1, "chainId": 1}'
+        == b'{"status": "PROPOSED", "score": "51623233060", "multiplier": 2, "tx_hash": null, "method": "createNode", "from": "0x1", "to": "0x2", "value": 1, "gasPrice": 1, "gas": 22000, "nonce": 1, "chainId": 1}'
     )  # noqa
 
 


### PR DESCRIPTION
This pull request makes a minor change to the `_make_record` method in `redis_wallet.py`. The update removes the explicit setting of the `gas` parameter to `None` when creating transaction records, which previously ensured gas would be re-estimated in TM.