### PR TITLE
Add legacy abi generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "sgx.py==0.11dev0",
     "skale-contracts==2.0.0a6",
     "typing-extensions==4.15.0",
-    "web3==7.13.0",
+    "web3==7.14.0",
 ]
 
 [project.optional-dependencies]

--- a/skale/skale_base.py
+++ b/skale/skale_base.py
@@ -23,8 +23,10 @@ import logging
 
 from skale_contracts import skale_contracts
 from skale_contracts.project_factory import SkaleProject
+from web3 import Web3
 
 from skale.utils.exceptions import EmptyWalletError, InvalidWalletError
+from skale.utils.helper import camel_to_snake_case
 from skale.utils.web3_utils import default_gas_price, get_endpoint, init_web3
 from skale.wallets import BaseWallet
 
@@ -93,3 +95,14 @@ class SkaleBase:
                 f'Wrong wallet class: {type(wallet).__name__}. \
                 Must be one of the BaseWallet subclasses'
             )
+
+    def _generate_legacy_abi(self) -> dict:
+        abi = {}
+        for contract_name in self.instance.abi.keys():
+            if contract_name == 'RewardWallet':  # RewardWallet requires node id to get address
+                continue
+            address = Web3.to_checksum_address(self.instance.get_contract_address(contract_name))
+            name = camel_to_snake_case(contract_name)
+            abi[f'{name}_abi'] = self.instance.abi[contract_name]
+            abi[f'{name}_address'] = address
+        return abi

--- a/skale/utils/helper.py
+++ b/skale/utils/helper.py
@@ -22,6 +22,7 @@ import ipaddress
 import json
 import logging
 import random
+import re
 import socket
 import string
 import sys
@@ -196,6 +197,10 @@ def split_public_key(public_key: str) -> list[bytes]:
 def to_camel_case(snake_str: str) -> str:
     components = snake_str.split('_')
     return components[0] + ''.join(x.title() for x in components[1:])
+
+
+def camel_to_snake_case(name: str) -> str:
+    return re.sub(r'(?<!^)(?=[A-Z])', '_', name).lower()
 
 
 def is_test_env() -> bool:

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -77,3 +77,11 @@ def test_get_attr(skale):
     skale_py_nodes_contract = skale.nodes
     assert issubclass(type(skale_py_nodes_contract), BaseContract)
     assert isinstance(skale_py_nodes_contract, Nodes)
+
+
+def test_legacy_abi_generation(skale):
+    abi_dict = skale._generate_legacy_abi()
+    assert 'nodes_abi' in abi_dict
+    assert 'nodes_address' in abi_dict
+    assert isinstance(abi_dict['nodes_abi'], list)
+    assert Web3.is_checksum_address(abi_dict['nodes_address'])


### PR DESCRIPTION
This pull request introduces support for legacy ABI generation and improves code consistency by adding a new utility function for converting camel case to snake case. It also updates the `web3` dependency and adds a corresponding test to ensure the new functionality works as expected.

**Legacy ABI Generation:**

* Added a private method `_generate_legacy_abi` to the `SkaleBase` class that constructs a dictionary mapping contract names (converted to snake case) to their ABI and checksum addresses, excluding `RewardWallet`. (`skale/skale_base.py`)
* Introduced a new utility function `camel_to_snake_case` in `skale/utils/helper.py` for consistent contract name formatting. (`skale/utils/helper.py`)
* Imported the new helper and `Web3` in `skale/skale_base.py` for use in ABI generation. (`skale/skale_base.py`)

**Dependency Update:**

* Upgraded `web3` dependency from `7.13.0` to `7.14.0` in `pyproject.toml`.

**Testing:**

* Added a test `test_legacy_abi_generation` in `tests/main_test.py` to verify the correctness of the legacy ABI generation, including contract name formatting and address checksumming.