### PR TITLE
IS-1316 Save previous committee only during transition period

### DIFF
--- a/scripts/export_env.sh
+++ b/scripts/export_env.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -ea
+
 export ENDPOINT=http://127.0.0.1:8545
 export MANAGER_TAG=1.12.0-develop.23
 export ALLOCATOR_TAG=2.2.2-develop.0

--- a/skale/fair_config/__init__.py
+++ b/skale/fair_config/__init__.py
@@ -1,2 +1,2 @@
 from .committee_history import generate_committee_history  # noqa
-from .committee_nodes import get_nodes_from_last_two_committees  # noqa
+from .committee_nodes import get_nodes_from_two_operational_committees  # noqa

--- a/skale/fair_config/committee_nodes.py
+++ b/skale/fair_config/committee_nodes.py
@@ -21,7 +21,7 @@ from eth_utils.address import to_checksum_address
 
 from skale.fair_config.utils import convert_to_node_for_chain_config
 from skale.fair_manager import FairManager
-from skale.types.committee import CommitteeGroup, CommitteeIndex, Timestamp
+from skale.types.committee import Committee, CommitteeGroup, CommitteeIndex
 from skale.types.node import FairNodeForChainConfig, NodeId, get_ghost_fair_node
 from skale.utils.constants import ZERO_ADDRESS
 
@@ -41,50 +41,57 @@ def get_committee_nodes(fair: FairManager, committee_index: int) -> list[FairNod
     return committee_nodes
 
 
+def create_committee_group(
+    fair: FairManager, committee_index: int, committee: Committee, timestamp: int
+) -> CommitteeGroup:
+    staking_contract_address = to_checksum_address(ZERO_ADDRESS)
+    if committee_index > 0:
+        staking_contract_address = to_checksum_address(fair.staking.contract.address)
+
+    committee = fair.committee.get_committee(CommitteeIndex(committee_index))
+    return {
+        'index': CommitteeIndex(committee_index),
+        'ts': committee.starting_timestamp,  # todod: remove, use from committee structure
+        'staking_contract_address': staking_contract_address,
+        'group': get_committee_nodes(fair, committee_index),
+        'committee': fair.committee.get_committee(CommitteeIndex(committee_index)),
+    }
+
+
 def get_nodes_from_last_two_committees(fair: FairManager) -> list[CommitteeGroup]:
     """
     Compose a dictionary with nodes from the last two committees.
     If it is the first committee, it will be saved both
     as first and second committee with first timestamp equal to 0
     """
+    latest_committee_index = fair.committee.last_committee_index()
 
-    latest_committee_index: int = fair.committee.last_committee_index()
     if latest_committee_index == 0:
-        committee_a_index: CommitteeIndex = CommitteeIndex(0)
-        committee_a = fair.committee.get_committee(CommitteeIndex(0))
-        ts_a = 0
+        first_committee = fair.committee.get_committee(CommitteeIndex(0))
+        return [
+            create_committee_group(fair, 0, first_committee, 0),
+            create_committee_group(fair, 0, first_committee, first_committee.starting_timestamp),
+        ]
+
+    latest_ts = fair.web3.eth.get_block('latest').get('timestamp', 0)
+    previous_committee_index = latest_committee_index - 1
+    previous_committee = fair.committee.get_committee(CommitteeIndex(previous_committee_index))
+
+    if latest_ts < previous_committee.starting_timestamp:
+        first_index = previous_committee_index
+        first_committee = previous_committee
     else:
-        committee_a_index: CommitteeIndex = CommitteeIndex(latest_committee_index - 1)  # type: ignore
-        committee_a = fair.committee.get_committee(CommitteeIndex(committee_a_index))
-        ts_a = committee_a.starting_timestamp
+        first_index = latest_committee_index
+        first_committee = fair.committee.get_committee(CommitteeIndex(latest_committee_index))
 
-    staking_contract_address = to_checksum_address(ZERO_ADDRESS)
-    if committee_a_index > 0:
-        staking_contract_address = to_checksum_address(fair.staking.contract.address)
+    second_committee_index = latest_committee_index
+    second_committee = fair.committee.get_committee(CommitteeIndex(second_committee_index))
 
-    committee_a_nodes_data: CommitteeGroup = {
-        'index': committee_a_index,
-        'ts': Timestamp(ts_a),  # todod: remove, use from committee structure
-        'staking_contract_address': staking_contract_address,
-        'group': get_committee_nodes(fair, committee_a_index),
-        'committee': committee_a,
-    }
-
-    committee_b_index = latest_committee_index
-
-    staking_contract_address = to_checksum_address(ZERO_ADDRESS)
-    if committee_b_index > 0:
-        staking_contract_address = to_checksum_address(fair.staking.contract.address)
-
-    committee_b = fair.committee.get_committee(CommitteeIndex(committee_b_index))
-    committee_b_nodes_data: CommitteeGroup = {
-        'index': CommitteeIndex(committee_b_index),
-        'ts': committee_b.starting_timestamp,  # todod: remove, use from committee structure
-        'staking_contract_address': staking_contract_address,
-        'group': get_committee_nodes(fair, committee_b_index),
-        'committee': fair.committee.get_committee(CommitteeIndex(committee_b_index)),
-    }
-
-    committee_nodes_data = [committee_a_nodes_data, committee_b_nodes_data]
-
-    return committee_nodes_data
+    return [
+        create_committee_group(
+            fair, first_index, first_committee, first_committee.starting_timestamp
+        ),
+        create_committee_group(
+            fair, second_committee_index, second_committee, second_committee.starting_timestamp
+        ),
+    ]

--- a/skale/fair_config/committee_nodes.py
+++ b/skale/fair_config/committee_nodes.py
@@ -72,14 +72,15 @@ def get_nodes_from_two_operational_committees(fair: FairManager) -> list[Committ
         first_committee = fair.committee.get_committee(CommitteeIndex(0))
         first_timestamp = Timestamp(0)
     else:
-        previous_committee_index = CommitteeIndex(latest_committee_index - 1)
-        previous_committee = fair.committee.get_committee(CommitteeIndex(previous_committee_index))
-
         latest_ts = fair.web3.eth.get_block('latest').get('timestamp', 0)
         first_index = latest_committee_index
         first_committee = latest_committee
 
-        if latest_ts < previous_committee.starting_timestamp:
+        if latest_ts < latest_committee.starting_timestamp:
+            previous_committee_index = CommitteeIndex(latest_committee_index - 1)
+            previous_committee = fair.committee.get_committee(
+                CommitteeIndex(previous_committee_index)
+            )
             first_index = previous_committee_index
             first_committee = previous_committee
 

--- a/skale/fair_config/committee_nodes.py
+++ b/skale/fair_config/committee_nodes.py
@@ -21,7 +21,7 @@ from eth_utils.address import to_checksum_address
 
 from skale.fair_config.utils import convert_to_node_for_chain_config
 from skale.fair_manager import FairManager
-from skale.types.committee import Committee, CommitteeGroup, CommitteeIndex
+from skale.types.committee import Committee, CommitteeGroup, CommitteeIndex, Timestamp
 from skale.types.node import FairNodeForChainConfig, NodeId, get_ghost_fair_node
 from skale.utils.constants import ZERO_ADDRESS
 
@@ -42,56 +42,54 @@ def get_committee_nodes(fair: FairManager, committee_index: int) -> list[FairNod
 
 
 def create_committee_group(
-    fair: FairManager, committee_index: int, committee: Committee, timestamp: int
+    fair: FairManager, committee_index: CommitteeIndex, committee: Committee, timestamp: Timestamp
 ) -> CommitteeGroup:
     staking_contract_address = to_checksum_address(ZERO_ADDRESS)
     if committee_index > 0:
         staking_contract_address = to_checksum_address(fair.staking.contract.address)
-
-    committee = fair.committee.get_committee(CommitteeIndex(committee_index))
     return {
-        'index': CommitteeIndex(committee_index),
-        'ts': committee.starting_timestamp,  # todod: remove, use from committee structure
+        'index': committee_index,
+        'ts': timestamp,  # todod: remove, use from committee structure
         'staking_contract_address': staking_contract_address,
         'group': get_committee_nodes(fair, committee_index),
-        'committee': fair.committee.get_committee(CommitteeIndex(committee_index)),
+        'committee': committee,
     }
 
 
-def get_nodes_from_last_two_committees(fair: FairManager) -> list[CommitteeGroup]:
+def get_nodes_from_two_operational_committees(fair: FairManager) -> list[CommitteeGroup]:
     """
-    Compose a dictionary with nodes from the last two committees.
+    Compose a dictionary with nodes from the two operational committees.
     If it is the first committee, it will be saved both
     as first and second committee with first timestamp equal to 0
+    If there are committee with timestamp in the future two latest committee will be saved.
+    Otherwise latest committee will be saved twice.
     """
     latest_committee_index = fair.committee.last_committee_index()
+    latest_committee = fair.committee.get_committee(CommitteeIndex(latest_committee_index))
 
     if latest_committee_index == 0:
+        first_index = CommitteeIndex(0)
         first_committee = fair.committee.get_committee(CommitteeIndex(0))
-        return [
-            create_committee_group(fair, 0, first_committee, 0),
-            create_committee_group(fair, 0, first_committee, first_committee.starting_timestamp),
-        ]
-
-    latest_ts = fair.web3.eth.get_block('latest').get('timestamp', 0)
-    previous_committee_index = latest_committee_index - 1
-    previous_committee = fair.committee.get_committee(CommitteeIndex(previous_committee_index))
-
-    if latest_ts < previous_committee.starting_timestamp:
-        first_index = previous_committee_index
-        first_committee = previous_committee
+        first_timestamp = Timestamp(0)
     else:
-        first_index = latest_committee_index
-        first_committee = fair.committee.get_committee(CommitteeIndex(latest_committee_index))
+        previous_committee_index = CommitteeIndex(latest_committee_index - 1)
+        previous_committee = fair.committee.get_committee(CommitteeIndex(previous_committee_index))
 
-    second_committee_index = latest_committee_index
-    second_committee = fair.committee.get_committee(CommitteeIndex(second_committee_index))
+        latest_ts = fair.web3.eth.get_block('latest').get('timestamp', 0)
+        first_index = latest_committee_index
+        first_committee = latest_committee
+
+        if latest_ts < previous_committee.starting_timestamp:
+            first_index = previous_committee_index
+            first_committee = previous_committee
+
+        first_timestamp = first_committee.starting_timestamp
+
+    second_index = latest_committee_index
+    second_committee = latest_committee
+    second_timestamp = second_committee.starting_timestamp
 
     return [
-        create_committee_group(
-            fair, first_index, first_committee, first_committee.starting_timestamp
-        ),
-        create_committee_group(
-            fair, second_committee_index, second_committee, second_committee.starting_timestamp
-        ),
+        create_committee_group(fair, first_index, first_committee, first_timestamp),
+        create_committee_group(fair, second_index, second_committee, second_timestamp),
     ]

--- a/tests/fair/fair_config_test.py
+++ b/tests/fair/fair_config_test.py
@@ -1,7 +1,7 @@
 import socket
 from unittest.mock import Mock
 
-from skale.fair_config.committee_nodes import get_nodes_from_last_two_committees
+from skale.fair_config.committee_nodes import get_nodes_from_two_operational_committees
 from skale.types.committee import Committee, CommitteeIndex, Timestamp
 from skale.types.dkg import DkgId, Fp2Point, G2Point
 from skale.types.node import FairNode, NodeId
@@ -60,7 +60,7 @@ def test_get_nodes_from_last_two_committees_first_committee():
     fair.staking.get_reward_wallet.side_effect = lambda node_id: f'0xreward{node_id}'
     fair.node.get_public_key.side_effect = lambda node_id: f'0xpublickey{node_id}'
 
-    result = get_nodes_from_last_two_committees(fair)
+    result = get_nodes_from_two_operational_committees(fair)
 
     assert len(result) == 2
     assert result[0]['index'] == 0
@@ -100,7 +100,7 @@ def test_get_nodes_from_last_two_committees_multiple_committees():
     fair.staking.get_reward_wallet.return_value = '0xreward'
     fair.node.get_public_key.side_effect = lambda node_id: f'0xpublickey{node_id}'
 
-    result = get_nodes_from_last_two_committees(fair)
+    result = get_nodes_from_two_operational_committees(fair)
 
     assert len(result) == 2
     assert result[0]['index'] == 1
@@ -127,7 +127,7 @@ def test_get_nodes_from_last_two_committees_structure():
     fair.staking.get_reward_wallet.return_value = '0xreward'
     fair.node.get_public_key.side_effect = lambda node_id: f'0xpublickey{node_id}'
 
-    result = get_nodes_from_last_two_committees(fair)
+    result = get_nodes_from_two_operational_committees(fair)
 
     for group in result:
         assert 'index' in group

--- a/tests/fair/fair_config_test.py
+++ b/tests/fair/fair_config_test.py
@@ -74,6 +74,8 @@ def test_get_nodes_from_last_two_committees_first_committee():
 def test_get_nodes_from_last_two_committees_multiple_committees():
     fair = Mock()
     fair.committee.last_committee_index.return_value = 2
+    fair.nodes.active_node_exists.return_value = True
+    fair.web3.eth.get_block = Mock(return_value={'timestamp': 1018})
 
     node_ids_1 = [NodeId(1)]
     node_ids_2 = [NodeId(2)]


### PR DESCRIPTION
This pull request refactors the logic in `skale/fair_config/committee_nodes.py` for constructing committee group data. The main change is the introduction of the new `create_committee_group` helper function, which consolidates and simplifies the creation of committee group dictionaries. The code for collecting nodes from the last two committees is rewritten to use this new function, improving readability and maintainability.

Refactoring and simplification:

* Added the `create_committee_group` function to encapsulate committee group dictionary creation, centralizing repeated logic and reducing code duplication.
* Rewrote the `get_nodes_from_last_two_committees` function to use `create_committee_group`, streamlining the process of building committee group data for the last two committees and improving clarity.

Type and import adjustments:

* Updated imports to include `Committee` and removed unused `Timestamp` from `skale.types.committee`.