### PR TITLE
Improve gas estimation for alive tx

### DIFF
--- a/skale/contracts/fair/status.py
+++ b/skale/contracts/fair/status.py
@@ -55,7 +55,7 @@ class Status(BaseContract):
 
     def calc_alive_gas_limit(self) -> int:
         active_whitelisted_nodes = len(self.active_whitelisted_node_ids())
-        alive_gas_limit_float = 230000 * math.log(active_whitelisted_nodes + 15) + 420000
+        alive_gas_limit_float = (230000 * math.log10(active_whitelisted_nodes + 15) + 420000) * 1.2
         alive_gas_limit = int(alive_gas_limit_float)
         logger.info(
             'alive_gas_limit: %s, active_whitelisted_nodes: %s',


### PR DESCRIPTION
This pull request introduces a small but important adjustment to the calculation of the alive gas limit in the `calc_alive_gas_limit` method. The change modifies the formula to use a base-10 logarithm and applies a multiplier, which will affect the resulting gas limit values.

* Calculation update: In `skale/contracts/fair/status.py`, the formula for `alive_gas_limit_float` in the `calc_alive_gas_limit` method now uses `math.log10` instead of `math.log`, and multiplies the result by 1.2 to increase the calculated gas limit.