### PR TITLE
Fix committee generation

### DIFF
--- a/skale/fair_config/committee_nodes.py
+++ b/skale/fair_config/committee_nodes.py
@@ -75,6 +75,7 @@ def get_nodes_from_two_operational_committees(fair: FairManager) -> list[Committ
         latest_ts = fair.web3.eth.get_block('latest').get('timestamp', 0)
         first_index = latest_committee_index
         first_committee = latest_committee
+        first_timestamp = Timestamp(0)
 
         if latest_ts < latest_committee.starting_timestamp:
             previous_committee_index = CommitteeIndex(latest_committee_index - 1)
@@ -83,8 +84,7 @@ def get_nodes_from_two_operational_committees(fair: FairManager) -> list[Committ
             )
             first_index = previous_committee_index
             first_committee = previous_committee
-
-        first_timestamp = first_committee.starting_timestamp
+            first_timestamp = first_committee.starting_timestamp
 
     second_index = latest_committee_index
     second_committee = latest_committee


### PR DESCRIPTION
This pull request makes a minor adjustment to the logic for determining the starting timestamp of the first committee in the `get_nodes_from_two_operational_committees` function. The change ensures that `first_timestamp` is always initialized, either to zero or to the actual starting timestamp of the committee, depending on the branch taken.

* Ensured `first_timestamp` is always set, initializing it to `Timestamp(0)` by default and updating it to `first_committee.starting_timestamp` when appropriate. [[1]](diffhunk://#diff-7202ef73f299b1486a87691fd40f0ceb8a970815b4d69954742a77a96ebc8027R78) [[2]](diffhunk://#diff-7202ef73f299b1486a87691fd40f0ceb8a970815b4d69954742a77a96ebc8027L86)