### PR TITLE
Increase gas limit in alive gas calculation

### DIFF
--- a/skale/contracts/fair/status.py
+++ b/skale/contracts/fair/status.py
@@ -55,7 +55,7 @@ class Status(BaseContract):
 
     def calc_alive_gas_limit(self) -> int:
         active_whitelisted_nodes = len(self.active_whitelisted_node_ids())
-        alive_gas_limit_float = (230000 * math.log10(active_whitelisted_nodes + 15) + 420000) * 1.2
+        alive_gas_limit_float = (230000 * math.log10(active_whitelisted_nodes + 15) + 720000) * 1.2
         alive_gas_limit = int(alive_gas_limit_float)
         logger.info(
             'alive_gas_limit: %s, active_whitelisted_nodes: %s',


### PR DESCRIPTION
This pull request updates the calculation of the alive gas limit in the `calc_alive_gas_limit` method. The change increases the base value used in the formula, which will result in a higher gas limit for the same number of active whitelisted nodes.

Resource allocation adjustment:

* Increased the constant in the alive gas limit formula from `420000` to `720000` in the `calc_alive_gas_limit` method in `skale/contracts/fair/status.py`, raising the overall alive gas limit.