### PR TITLE
Fix erc20 token types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skale.py"
-version = "7.7"
+version = "7.8"
 description = "SKALE client tools"
 readme = "README.md"
 requires-python = ">=3.11,<4"

--- a/skale/__init__.py
+++ b/skale/__init__.py
@@ -4,9 +4,10 @@ if sys.version_info < (3, 7):
     raise EnvironmentError('Python 3.7 or above is required')
 
 from skale.fair_manager import FairManager
+from skale.mainnet_ima import MainnetIma
+from skale.mainnet_ima import MainnetIma as SkaleIma  # todo: deprecated, to be removed in v8
 from skale.schain_ima import SchainIma
 from skale.skale_allocator import SkaleAllocator
-from skale.skale_ima import SkaleIma
 from skale.skale_manager import SkaleManager
 
-__all__ = ['SkaleManager', 'SkaleAllocator', 'SkaleIma', 'FairManager', 'SchainIma']
+__all__ = ['SkaleManager', 'SkaleAllocator', 'SkaleIma', 'MainnetIma', 'FairManager', 'SchainIma']

--- a/skale/contracts/erc20_contract.py
+++ b/skale/contracts/erc20_contract.py
@@ -115,6 +115,10 @@ class Erc20Contract(BaseContract):
     def transfer(self, to: ChecksumAddress, amount: Wei) -> ContractFunction:
         return self.contract.functions.transfer(to, amount)
 
+    @transaction_method
+    def approve(self, spender: ChecksumAddress, amount: Wei) -> ContractFunction:
+        return self.contract.functions.approve(spender, amount)
+
     def wait_for_balance_change(
         self,
         address: ChecksumAddress,

--- a/skale/contracts/erc20_contract.py
+++ b/skale/contracts/erc20_contract.py
@@ -108,11 +108,11 @@ class Erc20Contract(BaseContract):
     ):
         super().__init__(web3, address, ERC20_ABI, wallet)
 
-    def balance_of(self, account: ChecksumAddress) -> int:
-        return self.contract.functions.balanceOf(account).call()
+    def balance_of(self, account: ChecksumAddress) -> Wei:
+        return Wei(self.contract.functions.balanceOf(account).call())
 
     @transaction_method
-    def transfer(self, to: ChecksumAddress, amount: int) -> ContractFunction:
+    def transfer(self, to: ChecksumAddress, amount: Wei) -> ContractFunction:
         return self.contract.functions.transfer(to, amount)
 
     def wait_for_balance_change(

--- a/skale/contracts/ima/mainnet/base_deposit_box.py
+++ b/skale/contracts/ima/mainnet/base_deposit_box.py
@@ -23,41 +23,19 @@ from web3.contract.contract import ContractFunction
 from skale.contracts.base_contract import transaction_method
 from skale.contracts.skale_contract import SkaleContract
 from skale.types.schain import SchainName
-from skale.utils.helper import schain_hash
 
 
-class CommunityPool(SkaleContract):
-    @transaction_method
-    def recharge_user_wallet(
-        self, schain_name: SchainName, address: ChecksumAddress
-    ) -> ContractFunction:
-        return self.contract.functions.rechargeUserWallet(schain_name, address)
+class BaseDepositBox(SkaleContract):
+    def is_whitelisted(self, schain_name: SchainName) -> bool:
+        return self.contract.functions.isWhitelisted(schain_name).call()
 
     @transaction_method
-    def withdraw_funds(self, schain_name: SchainName, amount: int) -> ContractFunction:
-        return self.contract.functions.withdrawFunds(schain_name, amount)
+    def enable_whitelist(self, schain_name: SchainName) -> ContractFunction:
+        return self.contract.functions.enableWhitelist(schain_name)
 
     @transaction_method
-    def set_min_transaction_gas(self, min_gas_value: int) -> ContractFunction:
-        return self.contract.functions.setMinTransactionGas(min_gas_value)
-
-    @transaction_method
-    def set_multiplier(self, new_numerator: int, new_divider: int) -> ContractFunction:
-        return self.contract.functions.setMultiplier(new_numerator, new_divider)
-
-    def get_balance(self, address: ChecksumAddress, schain_name: SchainName) -> int:
-        return self.contract.functions.getBalance(address, schain_name).call()
-
-    def check_user_balance(self, schain_name: SchainName, receiver: int) -> bool:
-        return self.contract.functions.checkUserBalance(schain_hash(schain_name), receiver).call()
-
-    def get_recommended_recharge_amount(self, schain_name: SchainName, receiver: int) -> int:
-        return self.contract.functions.getRecommendedRechargeAmount(
-            schain_hash(schain_name), receiver
-        ).call()
-
-    def constant_setter_role(self) -> bool:
-        return self.contract.functions.CONSTANT_SETTER_ROLE().call()
+    def disable_whitelist(self, schain_name: SchainName) -> ContractFunction:
+        return self.contract.functions.disableWhitelist(schain_name)
 
     def admin_role(self) -> bytes:
         return self.contract.functions.DEFAULT_ADMIN_ROLE().call()

--- a/skale/contracts/ima/mainnet/deposit_box_erc1155.py
+++ b/skale/contracts/ima/mainnet/deposit_box_erc1155.py
@@ -21,11 +21,11 @@ from eth_typing import ChecksumAddress
 from web3.contract.contract import ContractFunction
 
 from skale.contracts.base_contract import transaction_method
-from skale.contracts.skale_contract import SkaleContract
+from skale.contracts.ima.mainnet.base_deposit_box import BaseDepositBox
 from skale.types.schain import SchainName
 
 
-class DepositBoxERC1155(SkaleContract):
+class DepositBoxERC1155(BaseDepositBox):
     """Class deposit"""
 
     @transaction_method

--- a/skale/contracts/ima/mainnet/deposit_box_erc20.py
+++ b/skale/contracts/ima/mainnet/deposit_box_erc20.py
@@ -17,29 +17,16 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
 
-from Crypto.Hash import keccak
 from eth_typing import ChecksumAddress
 from web3.contract.contract import ContractFunction
 
 from skale.contracts.base_contract import transaction_method
-from skale.contracts.skale_contract import SkaleContract
+from skale.contracts.ima.mainnet.base_deposit_box import BaseDepositBox
 from skale.types.schain import SchainName
+from skale.utils.helper import schain_hash
 
 
-class DepositBoxERC20(SkaleContract):
-    """Deposit Box"""
-
-    def is_whitelisted(self, schain_name: SchainName) -> bool:
-        return self.contract.functions.isWhitelisted(schain_name).call()
-
-    @transaction_method
-    def enable_whitelist(self, schain_name: SchainName) -> ContractFunction:
-        return self.contract.functions.enableWhitelist(schain_name)
-
-    @transaction_method
-    def disable_whitelist(self, schain_name: SchainName) -> ContractFunction:
-        return self.contract.functions.disableWhitelist(schain_name)
-
+class DepositBoxERC20(BaseDepositBox):
     @transaction_method
     def add_erc20_token(
         self, schain_name: SchainName, address: ChecksumAddress
@@ -77,22 +64,10 @@ class DepositBoxERC20(SkaleContract):
         return self.contract.functions.trustReceiver(schain_name, address)
 
     def is_receiver_trusted(self, schain_name: SchainName, address: ChecksumAddress) -> bool:
-        keccak_hash = keccak.new(data=schain_name.encode('utf8'), digest_bits=256)
-        schain_id = keccak_hash.digest()
-        return self.contract.functions.isReceiverTrusted(schain_id, address).call()
+        return self.contract.functions.isReceiverTrusted(schain_hash(schain_name), address).call()
 
     def arbiter_role(self) -> bytes:
         return self.contract.functions.ARBITER_ROLE().call()
 
-    def admin_role(self) -> bytes:
-        return self.contract.functions.DEFAULT_ADMIN_ROLE().call()
-
-    def has_role(self, role: bytes, address: ChecksumAddress) -> bool:
-        return self.contract.functions.hasRole(role, address).call()
-
-    @transaction_method
-    def grant_role(self, role: bytes, address: ChecksumAddress) -> ContractFunction:
-        return self.contract.functions.grantRole(role, address)
-
-    def get_role_member(self, role: bytes, index: int) -> bytes:
-        return self.contract.functions.getRoleMember(role, index).call()
+    def is_token_added(self, schain_name: SchainName, erc20_on_mainnet: ChecksumAddress) -> bool:
+        return self.contract.functions.getSchainToERC20(schain_name, erc20_on_mainnet).call()

--- a/skale/contracts/ima/mainnet/deposit_box_erc721.py
+++ b/skale/contracts/ima/mainnet/deposit_box_erc721.py
@@ -21,11 +21,11 @@ from eth_typing import ChecksumAddress
 from web3.contract.contract import ContractFunction
 
 from skale.contracts.base_contract import transaction_method
-from skale.contracts.skale_contract import SkaleContract
+from skale.contracts.ima.mainnet.base_deposit_box import BaseDepositBox
 from skale.types.schain import SchainName
 
 
-class DepositBoxERC721(SkaleContract):
+class DepositBoxERC721(BaseDepositBox):
     @transaction_method
     def deposit_erc721(
         self, schain_name: SchainName, address: ChecksumAddress, tokenID: int

--- a/skale/contracts/ima/mainnet/deposit_box_erc721_wmt.py
+++ b/skale/contracts/ima/mainnet/deposit_box_erc721_wmt.py
@@ -21,11 +21,11 @@ from eth_typing import ChecksumAddress
 from web3.contract.contract import ContractFunction
 
 from skale.contracts.base_contract import transaction_method
-from skale.contracts.skale_contract import SkaleContract
+from skale.contracts.ima.mainnet.base_deposit_box import BaseDepositBox
 from skale.types.schain import SchainName
 
 
-class DepositBoxERC721WithMetadata(SkaleContract):
+class DepositBoxERC721WithMetadata(BaseDepositBox):
     @transaction_method
     def deposit_erc721(
         self, schain_name: SchainName, address: ChecksumAddress, tokenID: int

--- a/skale/contracts/ima/mainnet/deposit_box_eth.py
+++ b/skale/contracts/ima/mainnet/deposit_box_eth.py
@@ -17,16 +17,16 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
 
-from Crypto.Hash import keccak
 from eth_typing import ChecksumAddress
 from web3.contract.contract import ContractFunction
 
 from skale.contracts.base_contract import transaction_method
-from skale.contracts.skale_contract import SkaleContract
+from skale.contracts.ima.mainnet.base_deposit_box import BaseDepositBox
 from skale.types.schain import SchainName
+from skale.utils.helper import schain_hash
 
 
-class DepositBoxEth(SkaleContract):
+class DepositBoxEth(BaseDepositBox):
     @transaction_method
     def deposit(self, schain_name: SchainName) -> ContractFunction:
         return self.contract.functions.deposit(schain_name)
@@ -47,9 +47,7 @@ class DepositBoxEth(SkaleContract):
         return self.contract.functions.approveTransfers(address).call()
 
     def is_active_transfers(self, schain_name: SchainName) -> bool:
-        keccak_hash = keccak.new(data=schain_name.encode('utf8'), digest_bits=256)
-        hash = keccak_hash.digest()
-        return self.contract.functions.activeEthTransfers(hash).call()
+        return self.contract.functions.activeEthTransfers(schain_hash(schain_name)).call()
 
     @transaction_method
     def disable_active_eth_transfers(self, schain_name: SchainName) -> ContractFunction:

--- a/skale/contracts/ima/schain/base_token_manager.py
+++ b/skale/contracts/ima/schain/base_token_manager.py
@@ -1,0 +1,53 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of SKALE.py
+#
+#   Copyright (C) 2019-Present SKALE Labs
+#
+#   SKALE.py is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   SKALE.py is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
+
+from eth_typing import ChecksumAddress
+from web3.contract.contract import ContractFunction
+
+from skale.contracts.base_contract import transaction_method
+from skale.contracts.skale_contract import SkaleContract
+
+
+class BaseTokenManager(SkaleContract):
+    def automatic_deploy(self) -> bool:
+        return self.contract.functions.automaticDeploy().call()
+
+    @transaction_method
+    def enable_automatic_deploy(self) -> ContractFunction:
+        return self.contract.functions.enableAutomaticDeploy()
+
+    @transaction_method
+    def disable_automatic_deploy(self) -> ContractFunction:
+        return self.contract.functions.disableAutomaticDeploy()
+
+    def automatic_deploy_role(self) -> bytes:
+        return self.contract.functions.AUTOMATIC_DEPLOY_ROLE().call()
+
+    def token_registrar_role(self) -> bytes:
+        return self.contract.functions.TOKEN_REGISTRAR_ROLE().call()
+
+    def has_role(self, role: bytes, address: ChecksumAddress) -> bool:
+        return self.contract.functions.hasRole(role, address).call()
+
+    @transaction_method
+    def grant_role(self, role: bytes, address: ChecksumAddress) -> ContractFunction:
+        return self.contract.functions.grantRole(role, address)
+
+    def get_role_member(self, role: bytes, index: int) -> bytes:
+        return self.contract.functions.getRoleMember(role, index).call()

--- a/skale/contracts/ima/schain/community_locker.py
+++ b/skale/contracts/ima/schain/community_locker.py
@@ -17,13 +17,13 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
 
-from Crypto.Hash import keccak
 from eth_typing import ChecksumAddress
 from web3.contract.contract import ContractFunction
 
 from skale.contracts.base_contract import transaction_method
 from skale.contracts.skale_contract import SkaleContract
 from skale.types.schain import SchainName
+from skale.utils.helper import schain_hash
 
 
 class CommunityLocker(SkaleContract):
@@ -51,9 +51,9 @@ class CommunityLocker(SkaleContract):
         return self.contract.functions.grantRole(role, address)
 
     def check_allow_to_send_msg(self, schain_name: SchainName, address: ChecksumAddress) -> int:
-        keccak_hash = keccak.new(data=schain_name.encode('utf8'), digest_bits=256)
-        hash = keccak_hash.digest()
-        return self.contract.functions.checkAllowedToSendMessage(hash, address).call()
+        return self.contract.functions.checkAllowedToSendMessage(
+            schain_hash(schain_name), address
+        ).call()
 
     def schain_hash(self) -> bytes:
         return self.contract.functions.schainHash().call()
@@ -68,6 +68,4 @@ class CommunityLocker(SkaleContract):
         return self.contract.functions.lastMessageTimeStamp(address).call()
 
     def time_limit_per_msg(self, schain_name: SchainName) -> int:
-        keccak_hash = keccak.new(data=schain_name.encode('utf8'), digest_bits=256)
-        hash = keccak_hash.digest()
-        return self.contract.functions.timeLimitPerMessage(hash).call()
+        return self.contract.functions.timeLimitPerMessage(schain_hash(schain_name)).call()

--- a/skale/contracts/ima/schain/token_manager_erc1155.py
+++ b/skale/contracts/ima/schain/token_manager_erc1155.py
@@ -17,16 +17,16 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
 
-from Crypto.Hash import keccak
 from eth_typing import ChecksumAddress
 from web3.contract.contract import ContractFunction
 
 from skale.contracts.base_contract import transaction_method
-from skale.contracts.skale_contract import SkaleContract
+from skale.contracts.ima.schain.base_token_manager import BaseTokenManager
 from skale.types.schain import SchainName
+from skale.utils.helper import schain_hash
 
 
-class TokenManagerERC1155(SkaleContract):
+class TokenManagerERC1155(BaseTokenManager):
     @transaction_method
     def add_erc1155_token(
         self, schain_name: SchainName, token_mn: int, token_sc: int
@@ -66,29 +66,4 @@ class TokenManagerERC1155(SkaleContract):
         )
 
     def get_clones_erc1155(self, schain_name: SchainName, address: ChecksumAddress) -> int:
-        keccak_hash = keccak.new(data=schain_name.encode('utf8'), digest_bits=256)
-        hash = keccak_hash.digest()
-        return self.contract.functions.clonesErc1155(hash, address).call()
-
-    def enable_automatic_deploy(self) -> ContractFunction:
-        return self.contract.functions.enableAutomaticDeploy()
-
-    @transaction_method
-    def disable_automatic_deploy(self) -> ContractFunction:
-        return self.contract.functions.disableAutomaticDeploy()
-
-    def automatic_deploy_role(self) -> bytes:
-        return self.contract.functions.AUTOMATIC_DEPLOY_ROLE().call()
-
-    def token_registrar_role(self) -> bytes:
-        return self.contract.functions.TOKEN_REGISTRAR_ROLE().call()
-
-    def has_role(self, role: bytes, address: ChecksumAddress) -> bool:
-        return self.contract.functions.hasRole(role, address).call()
-
-    @transaction_method
-    def grant_role(self, role: bytes, address: ChecksumAddress) -> ContractFunction:
-        return self.contract.functions.grantRole(role, address)
-
-    def get_role_member(self, role: bytes, index: int) -> bytes:
-        return self.contract.functions.getRoleMember(role, index).call()
+        return self.contract.functions.clonesErc1155(schain_hash(schain_name), address).call()

--- a/skale/contracts/ima/schain/token_manager_erc20.py
+++ b/skale/contracts/ima/schain/token_manager_erc20.py
@@ -55,9 +55,14 @@ class TokenManagerERC20(BaseTokenManager):
 
     @transaction_method
     def add_erc20_token(
-        self, schain_name: SchainName, token_mn: int, token_sc: int
+        self,
+        origin_chain_name: SchainName,
+        origin_address: ChecksumAddress,
+        clone_address: ChecksumAddress,
     ) -> ContractFunction:
-        return self.contract.functions.addERC20TokenByOwner(schain_name, token_mn, token_sc)
+        return self.contract.functions.addERC20TokenByOwner(
+            origin_chain_name, origin_address, clone_address
+        )
 
     def get_clone(self, schain_name: SchainName, origin_address: ChecksumAddress) -> int:
         return self.contract.functions.clonesErc20(schain_hash(schain_name), origin_address).call()

--- a/skale/contracts/ima/schain/token_manager_erc20.py
+++ b/skale/contracts/ima/schain/token_manager_erc20.py
@@ -17,21 +17,16 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
 
-from Crypto.Hash import keccak
 from eth_typing import ChecksumAddress
 from web3.contract.contract import ContractFunction
 
 from skale.contracts.base_contract import transaction_method
-from skale.contracts.skale_contract import SkaleContract
+from skale.contracts.ima.schain.base_token_manager import BaseTokenManager
 from skale.types.schain import SchainName
+from skale.utils.helper import schain_hash
 
 
-class TokenManagerERC20(SkaleContract):
-    """Token manager ERC20"""
-
-    def automatic_deploy(self) -> bool:
-        return self.contract.functions.automaticDeploy().call()
-
+class TokenManagerERC20(BaseTokenManager):
     @transaction_method
     def exit_to_main_erc20(self, token_address: ChecksumAddress, amount: int) -> ContractFunction:
         return self.contract.functions.exitToMainERC20(token_address, amount)
@@ -64,32 +59,5 @@ class TokenManagerERC20(SkaleContract):
     ) -> ContractFunction:
         return self.contract.functions.addERC20TokenByOwner(schain_name, token_mn, token_sc)
 
-    @transaction_method
-    def enable_automatic_deploy(self) -> ContractFunction:
-        return self.contract.functions.enableAutomaticDeploy()
-
-    @transaction_method
-    def disable_automatic_deploy(self) -> ContractFunction:
-        return self.contract.functions.disableAutomaticDeploy()
-
-    def automatic_deploy_role(self) -> bytes:
-        return self.contract.functions.AUTOMATIC_DEPLOY_ROLE().call()
-
-    def token_registrar_role(self) -> bytes:
-        return self.contract.functions.TOKEN_REGISTRAR_ROLE().call()
-
-    def has_role(self, role: bytes, address: ChecksumAddress) -> bool:
-        return self.contract.functions.hasRole(role, address).call()
-
-    @transaction_method
-    def grant_role(self, role: bytes, address: ChecksumAddress) -> ContractFunction:
-        return self.contract.functions.grantRole(role, address)
-
-    def get_role_member(self, role: bytes, index: int) -> bytes:
-        return self.contract.functions.getRoleMember(role, index).call()
-
-    def get_clones_erc20(self, schain_name: SchainName, address: ChecksumAddress) -> int:
-        """schan_hash - origin chain, address - origin token address"""
-        keccak_hash = keccak.new(data=schain_name.encode('utf8'), digest_bits=256)
-        hash = keccak_hash.digest()
-        return self.contract.functions.clonesErc20(hash, address).call()
+    def get_clone(self, schain_name: SchainName, origin_address: ChecksumAddress) -> int:
+        return self.contract.functions.clonesErc20(schain_hash(schain_name), origin_address).call()

--- a/skale/contracts/ima/schain/token_manager_erc721.py
+++ b/skale/contracts/ima/schain/token_manager_erc721.py
@@ -17,23 +17,16 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
 
-from Crypto.Hash import keccak
 from eth_typing import ChecksumAddress
 from web3.contract.contract import ContractFunction
 
 from skale.contracts.base_contract import transaction_method
-from skale.contracts.skale_contract import SkaleContract
+from skale.contracts.ima.schain.base_token_manager import BaseTokenManager
 from skale.types.schain import SchainName
+from skale.utils.helper import schain_hash
 
 
-class TokenManagerERC721(SkaleContract):
-    def automatic_deploy(self) -> bool:
-        return self.contract.functions.automaticDeploy().call()
-
-    @transaction_method
-    def enable_automatic_deploy(self) -> ContractFunction:
-        return self.contract.functions.enableAutomaticDeploy()
-
+class TokenManagerERC721(BaseTokenManager):
     @transaction_method
     def add_erc721(self, schain_name: SchainName, token_mn: int, token_sc: int) -> ContractFunction:
         return self.contract.functions.addERC721TokenByOwner(schain_name, token_mn, token_sc)
@@ -46,30 +39,8 @@ class TokenManagerERC721(SkaleContract):
         return self.contract.functions.transferToSchainERC721(schain_name, address, token_id)
 
     @transaction_method
-    def disable_automatic_deploy(self) -> ContractFunction:
-        return self.contract.functions.disableAutomaticDeploy()
-
-    def automatic_deploy_role(self) -> bytes:
-        return self.contract.functions.AUTOMATIC_DEPLOY_ROLE().call()
-
-    def token_registrar_role(self) -> bytes:
-        return self.contract.functions.TOKEN_REGISTRAR_ROLE().call()
-
-    def has_role(self, role: bytes, address: ChecksumAddress) -> bool:
-        return self.contract.functions.hasRole(role, address).call()
-
-    @transaction_method
     def exit_to_main_erc721(self, address: ChecksumAddress, token_id: int) -> ContractFunction:
         return self.contract.functions.exitToMainERC721(address, token_id)
 
-    @transaction_method
-    def grant_role(self, role: bytes, address: ChecksumAddress) -> ContractFunction:
-        return self.contract.functions.grantRole(role, address)
-
-    def get_role_member(self, role: bytes, index: int) -> bytes:
-        return self.contract.functions.getRoleMember(role, index).call()
-
     def get_clones_erc721(self, schain_name: SchainName, address: ChecksumAddress) -> int:
-        keccak_hash = keccak.new(data=schain_name.encode('utf8'), digest_bits=256)
-        hash = keccak_hash.digest()
-        return self.contract.functions.clonesErc721(hash, address).call()
+        return self.contract.functions.clonesErc721(schain_hash(schain_name), address).call()

--- a/skale/contracts/ima/schain/token_manager_erc721_wmt.py
+++ b/skale/contracts/ima/schain/token_manager_erc721_wmt.py
@@ -17,28 +17,19 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
 
-from Crypto.Hash import keccak
 from eth_typing import ChecksumAddress
 from web3.contract.contract import ContractFunction
 
 from skale.contracts.base_contract import transaction_method
-from skale.contracts.skale_contract import SkaleContract
+from skale.contracts.ima.schain.base_token_manager import BaseTokenManager
 from skale.types.schain import SchainName
+from skale.utils.helper import schain_hash
 
 
-class TokenManagerERC721WithMetadata(SkaleContract):
-    """Token manager with metadata"""
-
-    def automatic_deploy(self) -> bool:
-        return self.contract.functions.automaticDeploy().call()
-
+class TokenManagerERC721WithMetadata(BaseTokenManager):
     @transaction_method
     def add_erc721(self, schain_name: SchainName, token_mn: int, token_sc: int) -> ContractFunction:
         return self.contract.functions.addERC721TokenByOwner(schain_name, token_mn, token_sc)
-
-    @transaction_method
-    def enable_automatic_deploy(self) -> ContractFunction:
-        return self.contract.functions.enableAutomaticDeploy()
 
     @transaction_method
     def transfer_to_schain_erc721(
@@ -48,30 +39,8 @@ class TokenManagerERC721WithMetadata(SkaleContract):
         return self.contract.functions.transferToSchainERC721(schain_name, address, token_id)
 
     @transaction_method
-    def disable_automatic_deploy(self) -> ContractFunction:
-        return self.contract.functions.disableAutomaticDeploy()
-
-    def automatic_deploy_role(self) -> bytes:
-        return self.contract.functions.AUTOMATIC_DEPLOY_ROLE().call()
-
-    @transaction_method
     def exit_to_main_erc721(self, address: ChecksumAddress, token_id: int) -> ContractFunction:
         return self.contract.functions.exitToMainERC721(address, token_id)
 
-    def token_registrar_role(self) -> bytes:
-        return self.contract.functions.TOKEN_REGISTRAR_ROLE().call()
-
-    def has_role(self, role: bytes, address: ChecksumAddress) -> bool:
-        return self.contract.functions.hasRole(role, address).call()
-
-    @transaction_method
-    def grant_role(self, role: bytes, address: ChecksumAddress) -> ContractFunction:
-        return self.contract.functions.grantRole(role, address)
-
-    def get_role_member(self, role: bytes, index: int) -> bytes:
-        return self.contract.functions.getRoleMember(role, index).call()
-
     def get_clones_erc721(self, schain_name: SchainName, address: ChecksumAddress) -> int:
-        keccak_hash = keccak.new(data=schain_name.encode('utf8'), digest_bits=256)
-        hash = keccak_hash.digest()
-        return self.contract.functions.clonesErc721(hash, address).call()
+        return self.contract.functions.clonesErc721(schain_hash(schain_name), address).call()

--- a/skale/contracts/ima/schain/token_manager_eth.py
+++ b/skale/contracts/ima/schain/token_manager_eth.py
@@ -20,10 +20,10 @@
 from web3.contract.contract import ContractFunction
 
 from skale.contracts.base_contract import transaction_method
-from skale.contracts.skale_contract import SkaleContract
+from skale.contracts.ima.schain.base_token_manager import BaseTokenManager
 
 
-class TokenManagerETH(SkaleContract):
+class TokenManagerETH(BaseTokenManager):
     @transaction_method
     def exit_to_main(self, amount: int) -> ContractFunction:
         return self.contract.functions.exitToMain(amount)

--- a/skale/contracts/paymaster/paymaster.py
+++ b/skale/contracts/paymaster/paymaster.py
@@ -17,21 +17,17 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
 
-from Crypto.Hash import keccak
 from eth_typing import ChecksumAddress
 from web3.contract.contract import ContractFunction
 
 from skale.contracts.base_contract import transaction_method
 from skale.contracts.skale_contract import SkaleContract
-from skale.types.schain import SchainHash, SchainName
+from skale.types.schain import SchainName
+from skale.utils.helper import schain_hash
 
 
 class Paymaster(SkaleContract):
     """Paymaster contract"""
-
-    def name_to_id(self, schain_name: SchainName) -> SchainHash:
-        keccak_hash = keccak.new(data=schain_name.encode('utf8'), digest_bits=256)
-        return SchainHash(keccak_hash.digest())
 
     @transaction_method
     def add_schain(self, schain_name: SchainName) -> ContractFunction:
@@ -39,8 +35,7 @@ class Paymaster(SkaleContract):
 
     @transaction_method
     def remove_schain(self, schain_name: SchainName) -> ContractFunction:
-        schain_id = self.name_to_id(schain_name)
-        return self.contract.functions.removeSchain(schain_id)
+        return self.contract.functions.removeSchain(schain_hash(schain_name))
 
     @transaction_method
     def add_validator(
@@ -88,8 +83,7 @@ class Paymaster(SkaleContract):
 
     @transaction_method
     def pay(self, schain_name: SchainName, month: int) -> ContractFunction:
-        schain_id = self.name_to_id(schain_name)
-        return self.contract.functions.pay(schain_id, month)
+        return self.contract.functions.pay(schain_hash(schain_name), month)
 
     @transaction_method
     def claim(self, to_address: ChecksumAddress) -> ContractFunction:
@@ -100,8 +94,7 @@ class Paymaster(SkaleContract):
         return self.contract.functions.setVersion(new_version)
 
     def get_schain_expiration_timestamp(self, schain_name: SchainName) -> ContractFunction:
-        schain_id = self.name_to_id(schain_name)
-        return self.contract.functions.getSchainExpirationTimestamp(schain_id).call()
+        return self.contract.functions.getSchainExpirationTimestamp(schain_hash(schain_name)).call()
 
     def get_reward_amount(self, validator_id: int) -> int:
         return self.contract.functions.getRewardAmount(validator_id).call()
@@ -138,8 +131,7 @@ class Paymaster(SkaleContract):
         return self.contract.functions.getSchainsNumber().call()
 
     def get_schain(self, schain_name: SchainName) -> list:
-        schain_id = self.name_to_id(schain_name)
-        return self.contract.functions.schains(schain_id).call()
+        return self.contract.functions.schains(schain_hash(schain_name)).call()
 
     def get_max_replenishment_period(self) -> int:
         return self.contract.functions.maxReplenishmentPeriod().call()

--- a/skale/mainnet_ima.py
+++ b/skale/mainnet_ima.py
@@ -35,7 +35,7 @@ from skale.contracts.ima.mainnet.message_proxy_for_mainnet import MessageProxyFo
 from skale.skale_base import SkaleBase
 
 
-class SkaleIma(SkaleBase):
+class MainnetIma(SkaleBase):
     @property
     def project_name(self) -> SkaleProject:
         return SkaleProject.MAINNET_IMA
@@ -53,26 +53,26 @@ class SkaleIma(SkaleBase):
         return CommunityPool(self, MainnetImaContract.COMMUNITY_POOL)
 
     @cached_property
-    def deposit_box_eth(self) -> DepositBoxEth:
+    def eth(self) -> DepositBoxEth:
         return DepositBoxEth(self, MainnetImaContract.DEPOSIT_BOX_ETH)
 
     @cached_property
-    def deposit_box_erc20(self) -> DepositBoxERC20:
+    def erc20(self) -> DepositBoxERC20:
         return DepositBoxERC20(self, MainnetImaContract.DEPOSIT_BOX_ERC20)
 
     @cached_property
-    def deposit_box_erc721(self) -> DepositBoxERC721:
+    def erc721(self) -> DepositBoxERC721:
         return DepositBoxERC721(self, MainnetImaContract.DEPOSIT_BOX_ERC721)
 
     @cached_property
-    def deposit_box_erc721_wmt(self) -> DepositBoxERC721WithMetadata:
+    def erc721_wmt(self) -> DepositBoxERC721WithMetadata:
         return DepositBoxERC721WithMetadata(self, MainnetImaContract.DEPOSIT_BOX_ERC721_WMT)
 
     @cached_property
-    def deposit_box_erc1155(self) -> DepositBoxERC1155:
+    def erc1155(self) -> DepositBoxERC1155:
         return DepositBoxERC1155(self, MainnetImaContract.DEPOSIT_BOX_ERC1155)
 
 
-def spawn_skale_ima_lib(skale_ima: SkaleIma) -> SkaleIma:
+def spawn_skale_ima_lib(skale_ima: MainnetIma) -> MainnetIma:
     """Clone skale ima object with the same wallet"""
-    return SkaleIma(skale_ima._endpoint, skale_ima.instance.address, skale_ima.wallet)
+    return MainnetIma(skale_ima._endpoint, skale_ima.instance.address, skale_ima.wallet)

--- a/skale/schain_ima.py
+++ b/skale/schain_ima.py
@@ -50,25 +50,25 @@ class SchainIma(SkaleBase):
         return CommunityLocker(self, SchainImaContract.COMMUNITY_LOCKER)
 
     @cached_property
-    def token_manager_eth(self) -> TokenManagerETH:
+    def eth(self) -> TokenManagerETH:
         return TokenManagerETH(self, SchainImaContract.TOKEN_MANAGER_ETH)
 
     @cached_property
-    def token_manager_erc20(self) -> TokenManagerERC20:
+    def erc20(self) -> TokenManagerERC20:
         return TokenManagerERC20(self, SchainImaContract.TOKEN_MANAGER_ERC20)
 
     @cached_property
-    def token_manager_erc721(self) -> TokenManagerERC721:
+    def erc721(self) -> TokenManagerERC721:
         return TokenManagerERC721(self, SchainImaContract.TOKEN_MANAGER_ERC721)
 
     @cached_property
-    def token_manager_erc721_wmt(self) -> TokenManagerERC721WithMetadata:
+    def erc721_wmt(self) -> TokenManagerERC721WithMetadata:
         return TokenManagerERC721WithMetadata(
             self, SchainImaContract.TOKEN_MANAGER_ERC721_WITH_META
         )
 
     @cached_property
-    def token_manager_erc1155(self) -> TokenManagerERC1155:
+    def erc1155(self) -> TokenManagerERC1155:
         return TokenManagerERC1155(self, SchainImaContract.TOKEN_MANAGER_ERC1155)
 
     @cached_property

--- a/skale/utils/helper.py
+++ b/skale/utils/helper.py
@@ -30,10 +30,12 @@ from logging import Formatter, StreamHandler
 from random import randint
 from typing import Any, Callable, Dict, Generator, List, cast
 
+from Crypto.Hash import keccak
 from eth_typing import ChecksumAddress
 
 from skale.config import ENV
 from skale.types.node import Port
+from skale.types.schain import SchainHash, SchainName
 
 logger = logging.getLogger(__name__)
 
@@ -207,3 +209,8 @@ def contract_name_to_snake_case(name: str) -> str:
 
 def is_test_env() -> bool:
     return 'pytest' in sys.modules or ENV == 'test'
+
+
+def schain_hash(schain_name: SchainName) -> SchainHash:
+    keccak_hash = keccak.new(data=schain_name.encode('utf8'), digest_bits=256)
+    return SchainHash(keccak_hash.digest())

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -7,8 +7,8 @@ from skale_contracts.projects.skale_manager import SkaleManagerContract
 from web3 import HTTPProvider, LegacyWebSocketProvider, Web3
 
 from skale import SkaleManager
-from skale.contracts.skale_contract import SkaleContract
 from skale.contracts.manager.nodes import Nodes
+from skale.contracts.skale_contract import SkaleContract
 from skale.utils.helper import get_skale_manager_address
 from skale.utils.web3_utils import init_web3
 from skale.wallets import Web3Wallet

--- a/tests/utils/account_tools_test.py
+++ b/tests/utils/account_tools_test.py
@@ -2,9 +2,6 @@
 
 from unittest import mock
 
-import pytest
-
-from skale.transactions.exceptions import TransactionNotMinedError
 from skale.utils.account_tools import (
     check_ether_balance,
     check_skale_balance,


### PR DESCRIPTION
This pull request updates the `ERC20Contract` class to improve type safety and clarity when handling token amounts. The main changes involve switching from the generic `int` type to the more explicit `Wei` type for both the `balance_of` return value and the `transfer` method's amount parameter.

Type safety and clarity improvements:

* Changed the return type of the `balance_of` method from `int` to `Wei`, and wrapped the returned value in a `Wei` object for explicitness. (`skale/contracts/erc20_contract.py`)
* Updated the `transfer` method to require the `amount` parameter to be of type `Wei` instead of `int`, ensuring consistent usage of the `Wei` type throughout the contract interface. (`skale/contracts/erc20_contract.py`)