### PR TITLE
Add credit station project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skale.py"
-version = "7.8"
+version = "7.9"
 description = "SKALE client tools"
 readme = "README.md"
 requires-python = ">=3.11,<4"
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "redis>=7.0.1",
     "sgx.py==0.11dev0",
-    "skale-contracts==2.0.0a6",
+    "skale-contracts==2.0.0a10",
     "typing-extensions==4.15.0",
     "web3==7.14.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skale.py"
-version = "7.9"
+version = "7.92"
 description = "SKALE client tools"
 readme = "README.md"
 requires-python = ">=3.11,<4"
@@ -54,6 +54,10 @@ prerelease = "allow"
 
 [tool.hatch.build.targets.wheel]
 packages = ["skale"]
+only-include = ["skale"]
+
+[tool.hatch.build.targets.wheel.shared-data]
+"skale/py.typed" = "skale/py.typed"
 
 [tool.pytest.ini_options]
 log_cli = false

--- a/skale/__init__.py
+++ b/skale/__init__.py
@@ -1,13 +1,24 @@
 import sys
 
-if sys.version_info < (3, 7):
-    raise EnvironmentError('Python 3.7 or above is required')
+if sys.version_info < (3, 11):
+    raise EnvironmentError('Python 3.11 or above is required')
 
 from skale.fair_manager import FairManager
+from skale.mainnet_credit_station import MainnetCreditStation
 from skale.mainnet_ima import MainnetIma
 from skale.mainnet_ima import MainnetIma as SkaleIma  # todo: deprecated, to be removed in v8
+from skale.schain_credit_station import SchainCreditStation
 from skale.schain_ima import SchainIma
 from skale.skale_allocator import SkaleAllocator
 from skale.skale_manager import SkaleManager
 
-__all__ = ['SkaleManager', 'SkaleAllocator', 'SkaleIma', 'MainnetIma', 'FairManager', 'SchainIma']
+__all__ = [
+    'SkaleManager',
+    'SkaleAllocator',
+    'SkaleIma',
+    'MainnetIma',
+    'FairManager',
+    'SchainIma',
+    'MainnetCreditStation',
+    'SchainCreditStation',
+]

--- a/skale/contracts/credit_station/credit_station.py
+++ b/skale/contracts/credit_station/credit_station.py
@@ -1,0 +1,111 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of SKALE.py
+#
+#   Copyright (C) 2025-Present SKALE Labs
+#
+#   SKALE.py is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   SKALE.py is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+
+from eth_typing import ChecksumAddress
+from web3.contract.contract import ContractEvent, ContractFunction
+from web3.types import EventData, Wei
+
+from skale.contracts.base_contract import transaction_method
+from skale.contracts.skale_contract import SkaleContract
+from skale.types.credit_station import PaymentReceivedEvent
+from skale.types.schain import SchainName
+from skale.utils.helper import schain_hash
+
+logger = logging.getLogger(__name__)
+
+
+def get_events_in_chunks(
+    event: ContractEvent,
+    from_block: int,
+    to_block: int | None = None,
+    chunk_size: int = 10000,
+    **filter_args,
+) -> list[EventData]:
+    if to_block is None:
+        to_block = event.w3.eth.block_number
+
+    events = []
+    current_block = from_block
+    logger.info(f'Fetching events: {from_block} - {to_block}, chunk_size: {chunk_size}')
+    while current_block <= to_block:
+        logger.info(
+            f'Fetching chunk: {current_block} - {min(current_block + chunk_size - 1, to_block)}'
+        )
+        end_block = min(current_block + chunk_size - 1, to_block)
+        chunk_events = event.get_logs(
+            from_block=current_block, to_block=end_block, argument_filters=filter_args
+        )
+        events.extend(chunk_events)
+        current_block = end_block + 1
+    return events
+
+
+class CreditStation(SkaleContract):
+    @transaction_method
+    def buy(
+        self, schain_name: SchainName, purchaser: ChecksumAddress, token: ChecksumAddress
+    ) -> ContractFunction:
+        return self.contract.functions.buy(schain_name, purchaser, token)
+
+    @transaction_method
+    def set_price(self, token: ChecksumAddress, price: Wei) -> ContractFunction:
+        return self.contract.functions.setPrice(token, price)
+
+    def get_price(self, token: ChecksumAddress) -> Wei:
+        return self.contract.functions.getPrice(token).call()
+
+    def get_prices(self) -> dict[ChecksumAddress, Wei]:
+        tokens = self.get_supported_tokens()
+        return {token: self.get_price(token) for token in tokens}
+
+    def get_supported_tokens(self) -> list[ChecksumAddress]:
+        return self.contract.functions.getSupportedTokens().call()
+
+    def is_token_accepted(self, token: ChecksumAddress) -> bool:
+        return self.contract.functions.isTokenAccepted(token).call()
+
+    def get_payment_received_events(
+        self,
+        from_block: int = 0,
+        to_block: int | None = None,
+        chunk_size: int = 50000,
+        schain_name: SchainName | None = None,
+    ) -> list[PaymentReceivedEvent]:
+        filter_args = {}
+        if schain_name is not None:
+            _schain_hash = schain_hash(schain_name)
+            filter_args['schainHash'] = _schain_hash
+
+        events = get_events_in_chunks(
+            self.contract.events.PaymentReceived, from_block, to_block, chunk_size, **filter_args
+        )
+
+        return [
+            PaymentReceivedEvent(
+                payment_id=event['args']['id'],
+                schain_hash=event['args']['schainHash'],
+                from_address=event['args']['from'],
+                to_address=event['args']['to'],
+                token_address=event['args']['tokenAddress'],
+                block_number=event['blockNumber'],
+            )
+            for event in events
+        ]

--- a/skale/contracts/credit_station/ledger.py
+++ b/skale/contracts/credit_station/ledger.py
@@ -1,0 +1,35 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of SKALE.py
+#
+#   Copyright (C) 2025-Present SKALE Labs
+#
+#   SKALE.py is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   SKALE.py is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
+
+from eth_typing import ChecksumAddress
+from web3.contract.contract import ContractFunction
+from web3.types import Wei
+
+from skale.contracts.base_contract import transaction_method
+from skale.contracts.skale_contract import SkaleContract
+from skale.types.credit_station import PaymentId
+
+
+class Ledger(SkaleContract):
+    @transaction_method
+    def fulfill(self, payment: PaymentId, purchaser: ChecksumAddress) -> ContractFunction:
+        return self.contract.functions.fulfill(payment, purchaser)
+
+    def is_fulfilled(self, payment: PaymentId) -> Wei:
+        return self.contract.functions.isFulfilled(payment).call()

--- a/skale/mainnet_credit_station.py
+++ b/skale/mainnet_credit_station.py
@@ -1,0 +1,36 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of SKALE.py
+#
+#   Copyright (C) 2025-Present SKALE Labs
+#
+#   SKALE.py is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   SKALE.py is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
+
+from functools import cached_property
+
+from skale_contracts.project_factory import SkaleProject
+from skale_contracts.projects.credit_station import MainnetCreditStationContract
+
+from skale.contracts.credit_station.credit_station import CreditStation
+from skale.skale_base import SkaleBase
+
+
+class MainnetCreditStation(SkaleBase):
+    @property
+    def project_name(self) -> SkaleProject:
+        return SkaleProject.MAINNET_CREDIT_STATION
+
+    @cached_property
+    def credit_station(self) -> CreditStation:
+        return CreditStation(self, MainnetCreditStationContract.CREDIT_STATION)

--- a/skale/schain_credit_station.py
+++ b/skale/schain_credit_station.py
@@ -1,0 +1,36 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of SKALE.py
+#
+#   Copyright (C) 2025-Present SKALE Labs
+#
+#   SKALE.py is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   SKALE.py is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
+
+from functools import cached_property
+
+from skale_contracts.project_factory import SkaleProject
+from skale_contracts.projects.credit_station import SchainCreditStationContract
+
+from skale.contracts.credit_station.ledger import Ledger
+from skale.skale_base import SkaleBase
+
+
+class SchainCreditStation(SkaleBase):
+    @property
+    def project_name(self) -> SkaleProject:
+        return SkaleProject.SCHAIN_CREDIT_STATION
+
+    @cached_property
+    def ledger(self) -> Ledger:
+        return Ledger(self, SchainCreditStationContract.LEDGER)

--- a/skale/types/credit_station.py
+++ b/skale/types/credit_station.py
@@ -1,0 +1,33 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of SKALE.py
+#
+#   Copyright (C) 2025-Present SKALE Labs
+#
+#   SKALE.py is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   SKALE.py is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import NewType, TypedDict
+
+from eth_typing import ChecksumAddress, HexStr
+
+PaymentId = NewType('PaymentId', int)
+
+
+class PaymentReceivedEvent(TypedDict):
+    payment_id: PaymentId
+    schain_hash: HexStr
+    from_address: ChecksumAddress
+    to_address: ChecksumAddress
+    token_address: ChecksumAddress
+    block_number: int


### PR DESCRIPTION
This pull request introduces new Credit Station functionality to the SKALE Python client, including support for mainnet and schain credit stations, event handling, and contract interactions. It also updates dependencies and raises the minimum required Python version to 3.11. The most important changes are grouped below.

**New Credit Station features:**

* Added `MainnetCreditStation` and `SchainCreditStation` classes for interacting with mainnet and schain credit station contracts, including their respective contract wrappers and ledger support. (`skale/mainnet_credit_station.py`, `skale/schain_credit_station.py`, `skale/contracts/credit_station/credit_station.py`, `skale/contracts/credit_station/ledger.py`, [[1]](diffhunk://#diff-47ade1cd1847139e4b519c2a2690b3df4f5fbf6c184c558cc23d811949becce8L3-R24) [[2]](diffhunk://#diff-f854007f2ba81e4424d42d7c63ec0a153d26f64394cf1ef03922ee9c93b0ccbaR1-R36) [[3]](diffhunk://#diff-c85e807753122bc6cf7dbd3bd4cd9fe73ee4386f92f939a734fe81aa1d446f1eR1-R36) [[4]](diffhunk://#diff-b939638b99f63d3f3815962d9f4b146703b88844966efd16eb779f319dca386eR1-R111) [[5]](diffhunk://#diff-f88c98277bc764ebaee76422ebd09068d079629093d2fcc40620a08919708360R1-R35)
* Introduced event handling and types for credit station payments in `skale/types/credit_station.py`.

**API and compatibility updates:**

* Updated the minimum required Python version to 3.11 in `pyproject.toml` and enforced this in `skale/__init__.py`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-47ade1cd1847139e4b519c2a2690b3df4f5fbf6c184c558cc23d811949becce8L3-R24)
* Updated the `skale-contracts` dependency to version `2.0.0a10` to support new features.

**Public API changes:**

* Added `MainnetCreditStation` and `SchainCreditStation` to the public API via `skale/__init__.py`.