### PR TITLE
Add get public keys function - nodes contract

### DIFF
--- a/skale/contracts/manager/nodes.py
+++ b/skale/contracts/manager/nodes.py
@@ -104,6 +104,9 @@ class Nodes(SkaleManagerContract):
             if self.get_node_status(NodeId(node_id)) == NodeStatus.ACTIVE
         ]
 
+    def get_public_keys(self, node_ids: list[NodeId]) -> list[tuple[NodeId, str]]:
+        return [(node_id, self.get_node_public_key(node_id)) for node_id in node_ids]
+
     def name_to_id(self, name: str) -> bytes:
         keccak_hash = keccak.new(data=name.encode('utf8'), digest_bits=256)
         return keccak_hash.digest()


### PR DESCRIPTION
This pull request adds a new utility method to the `Nodes` contract manager to make it easier to retrieve public keys for a list of node IDs.

New utility method:

* Added `get_public_keys` to `skale/contracts/manager/nodes.py`, which returns a list of `(NodeId, public_key)` tuples for the provided node IDs.