### PR TITLE
Add custom session to track calls, add stats object

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,8 @@ only-include = ["skale"]
 "skale/py.typed" = "skale/py.typed"
 
 [tool.pytest.ini_options]
-log_cli = false
-log_cli_level = "INFO"
+log_cli = true
+log_cli_level = "WARNING"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 filterwarnings = ["ignore::DeprecationWarning"]

--- a/skale/rpc_session.py
+++ b/skale/rpc_session.py
@@ -1,0 +1,81 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of SKALE.py
+#
+#   Copyright (C) 2025-Present SKALE Labs
+#
+#   SKALE.py is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   SKALE.py is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with SKALE.py.  If not, see <https://www.gnu.org/licenses/>.
+
+import json
+from collections import Counter
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Any
+
+import requests
+
+
+@dataclass(slots=True)
+class RpcHttpStats:
+    http_posts: int = 0
+    rpc_objects: int = 0
+    by_method: Counter[str] = field(default_factory=Counter)
+    transport_errors: int = 0
+
+
+class CountingSession(requests.Session):
+    def __init__(self, stats: RpcHttpStats):
+        super().__init__()
+        self.stats = stats
+        self._lock = Lock()
+
+    def request(self, *args: Any, **kwargs: Any) -> requests.Response:
+        method = str(args[0]) if args else str(kwargs.get('method', ''))
+        if method.upper() == 'POST':
+            n, methods = _count_jsonrpc(kwargs)
+            with self._lock:
+                self.stats.http_posts += 1
+                self.stats.rpc_objects += n
+                self.stats.by_method.update(methods)
+            try:
+                return super().request(*args, **kwargs)
+            except Exception:
+                with self._lock:
+                    self.stats.transport_errors += 1
+                raise
+
+        return super().request(*args, **kwargs)
+
+
+def _count_jsonrpc(kwargs: dict[str, Any]) -> tuple[int, list[str]]:
+    payload = kwargs.get('json')
+    if payload is None:
+        data = kwargs.get('data')
+        if isinstance(data, (bytes, bytearray)):
+            data = data.decode('utf-8', errors='replace')
+        if isinstance(data, str):
+            try:
+                payload = json.loads(data)
+            except Exception:
+                return 0, []
+
+    if isinstance(payload, dict):
+        method = payload.get('method')
+        return 1, [method] if isinstance(method, str) else []
+
+    if isinstance(payload, list):
+        methods = [obj.get('method') for obj in payload if isinstance(obj, dict)]
+        return len(payload), [method for method in methods if isinstance(method, str)]
+
+    return 0, []

--- a/skale/schain_config/rotation_history.py
+++ b/skale/schain_config/rotation_history.py
@@ -40,17 +40,20 @@ class PreviousNodeData(TypedDict):
     previous_node_id: NodeId
 
 
+NodeGroups = Dict[int, NodesGroup]
+
+
 def get_previous_schain_groups(
     skale: SkaleManager,
     schain_name: SchainName,
     leaving_node_id: NodeId | None = None,
-) -> Dict[int, NodesGroup]:
+) -> NodeGroups:
     """
     Returns all previous node groups with public keys and finish timestamps.
     In case of no rotations returns the current state.
     """
     logger.info(f'Collecting rotation history for {schain_name}...')
-    node_groups: dict[int, NodesGroup] = {}
+    node_groups: NodeGroups = {}
 
     group_id = schain_name_to_hash(schain_name)
 
@@ -79,7 +82,7 @@ def get_previous_schain_groups(
 
 def _add_current_schain_state(
     skale: SkaleManager,
-    node_groups: dict[int, NodesGroup],
+    node_groups: NodeGroups,
     rotation: Rotation,
     schain_name: SchainName,
     current_public_key: G2Point,
@@ -104,7 +107,7 @@ def _add_current_schain_state(
 
 def _add_previous_schain_rotations_state(
     skale: SkaleManager,
-    node_groups: dict[int, NodesGroup],
+    node_groups: NodeGroups,
     rotation: Rotation,
     schain_name: SchainName,
     previous_public_keys: list[G2Point],

--- a/skale/schain_config/rotation_history.py
+++ b/skale/schain_config/rotation_history.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from skale.skale_manager import SkaleManager
     from skale.types.dkg import G2Point
     from skale.types.node import NodeId
-    from skale.types.rotation import BlsPublicKey, NodesGroup, Rotation
+    from skale.types.rotation import BlsPublicKey, NodeGroups, Rotation
     from skale.types.schain import SchainName
 
 logger = logging.getLogger(__name__)
@@ -38,9 +38,6 @@ logger = logging.getLogger(__name__)
 class PreviousNodeData(TypedDict):
     finish_ts: int
     previous_node_id: NodeId
-
-
-NodeGroups = Dict[int, NodesGroup]
 
 
 def get_previous_schain_groups(

--- a/skale/skale_base.py
+++ b/skale/skale_base.py
@@ -52,6 +52,7 @@ class SkaleBase:
         provider_timeout: int = 30,
         debug: bool = False,
         session: requests.Session | None = None,
+        enable_stats: bool = False,
     ):
         logger.info(
             'Initializing %s, endpoint: %s, alias_or_address: %s, wallet: %s',
@@ -65,7 +66,7 @@ class SkaleBase:
                 'state_path is deprecated and will be ignored. This option will be removed in v8.'
             )
         self.stats = RpcHttpStats()
-        if session is None:
+        if session is None and enable_stats:
             session = CountingSession(self.stats)
         self._endpoint = get_endpoint(endpoint, ts_diff=ts_diff, provider_timeout=provider_timeout)
         self._alias_or_address = alias_or_address

--- a/skale/skale_base.py
+++ b/skale/skale_base.py
@@ -21,10 +21,12 @@
 import abc
 import logging
 
+import requests
 from skale_contracts import skale_contracts
 from skale_contracts.project_factory import SkaleProject
 from web3 import Web3
 
+from skale.rpc_session import CountingSession, RpcHttpStats
 from skale.utils.exceptions import EmptyWalletError, InvalidWalletError
 from skale.utils.helper import contract_name_to_snake_case
 from skale.utils.web3_utils import default_gas_price, get_endpoint, init_web3
@@ -49,6 +51,7 @@ class SkaleBase:
         ts_diff: int | None = None,
         provider_timeout: int = 30,
         debug: bool = False,
+        session: requests.Session | None = None,
     ):
         logger.info(
             'Initializing %s, endpoint: %s, alias_or_address: %s, wallet: %s',
@@ -61,9 +64,17 @@ class SkaleBase:
             logger.warning(
                 'state_path is deprecated and will be ignored. This option will be removed in v8.'
             )
+        self.stats = RpcHttpStats()
+        if session is None:
+            session = CountingSession(self.stats)
         self._endpoint = get_endpoint(endpoint, ts_diff=ts_diff, provider_timeout=provider_timeout)
         self._alias_or_address = alias_or_address
-        self.web3 = init_web3(self._endpoint, ts_diff=ts_diff, provider_timeout=provider_timeout)
+        self.web3 = init_web3(
+            self._endpoint,
+            ts_diff=ts_diff,
+            provider_timeout=provider_timeout,
+            session=session,
+        )
         self.network = skale_contracts.get_network_by_provider(self.web3.provider)
         self.project = self.network.get_project(self.project_name)
         self.instance = self.project.get_instance(alias_or_address)

--- a/skale/types/rotation.py
+++ b/skale/types/rotation.py
@@ -46,6 +46,9 @@ class NodesGroup(TypedDict):
     bls_public_key: BlsPublicKey | None
 
 
+NodeGroups = dict[int, NodesGroup]
+
+
 @dataclass
 class Rotation:
     leaving_node_id: NodeId

--- a/skale/utils/web3_utils.py
+++ b/skale/utils/web3_utils.py
@@ -77,7 +77,7 @@ def init_web3(
         timeout=provider_timeout,
         session=session,
     )
-    # provider.cache_allowed_requests = True
+    provider.cache_allowed_requests = True
     w3 = Web3(provider)
     if not middlewares:
         ts_diff = ts_diff or config.ALLOWED_TS_DIFF

--- a/skale/utils/web3_utils.py
+++ b/skale/utils/web3_utils.py
@@ -22,6 +22,7 @@ import time
 from typing import Any, Dict, Iterable
 from urllib.parse import urlparse
 
+import requests
 from eth_keys.main import lazy_key_api as keys
 from eth_typing import Address, AnyAddress, ChecksumAddress, HexStr
 from requests.exceptions import ConnectionError  # type: ignore
@@ -47,7 +48,10 @@ DEFAULT_BLOCKS_TO_WAIT = 50
 
 
 def get_provider(
-    endpoint: str, timeout: int = DEFAULT_HTTP_TIMEOUT, request_kwargs: Dict[str, Any] | None = None
+    endpoint: str,
+    timeout: int = DEFAULT_HTTP_TIMEOUT,
+    request_kwargs: Dict[str, Any] | None = None,
+    session: Any = None,
 ) -> JSONBaseProvider:
     scheme = urlparse(endpoint).scheme
     if scheme == 'ws' or scheme == 'wss':
@@ -56,7 +60,7 @@ def get_provider(
 
     if scheme == 'http' or scheme == 'https':
         kwargs = {'timeout': timeout, **(request_kwargs or {})}
-        return HTTPProvider(endpoint, request_kwargs=kwargs)
+        return HTTPProvider(endpoint, session=session, request_kwargs=kwargs)
 
     raise Exception('Wrong endpoint option.Supported endpoint schemes: http/https/ws/wss')
 
@@ -66,8 +70,14 @@ def init_web3(
     provider_timeout: int = DEFAULT_HTTP_TIMEOUT,
     middlewares: Iterable[Middleware] | None = None,
     ts_diff: int | None = None,
+    session: requests.Session | None = None,
 ) -> Web3:
-    provider = get_provider(endpoint, timeout=provider_timeout)
+    provider = get_provider(
+        endpoint,
+        timeout=provider_timeout,
+        session=session,
+    )
+    # provider.cache_allowed_requests = True
     w3 = Web3(provider)
     if not middlewares:
         ts_diff = ts_diff or config.ALLOWED_TS_DIFF

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """SKALE config test"""
 
+import logging
 from unittest import mock
 
 import pytest
@@ -29,6 +30,9 @@ from tests.constants import ENDPOINT, TEST_ABI_FILEPATH
 from tests.helper import init_fair, init_skale, init_skale_allocator
 
 ETH_AMOUNT_PER_NODE = 1
+logger = logging.getLogger(__name__)
+
+_last_finished_test_name: str | None = None
 
 
 @pytest.fixture(scope='session')
@@ -50,6 +54,37 @@ def skale(web3, request):
         deploy_fake_multisig_contract(skale_obj.web3, skale_obj.wallet)
         request.config._cached_skale = skale_obj
     return request.config._cached_skale
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    report = outcome.get_result()
+    if report.when == 'call' and report.outcome in {'passed', 'failed', 'skipped'}:
+        item.config._last_finished_test_name = item.name
+
+
+@pytest.fixture(scope='session')
+def _skale_stats_logger(skale):
+    def _log(test_name: str) -> None:
+        logger.warning(
+            test_name
+            + ' '
+            + str(skale.stats.http_posts)
+            + ' '
+            + str(skale.stats.by_method.most_common(10))
+        )
+
+    return _log
+
+
+@pytest.fixture(autouse=True)
+def log_prev_test_stats(request, _skale_stats_logger):
+    global _last_finished_test_name
+    prev_name = getattr(request.config, '_last_finished_test_name', None)
+    if prev_name is not None:
+        _skale_stats_logger(prev_name)
+    _last_finished_test_name = request.node.name
 
 
 @pytest.fixture(scope='session')

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -39,7 +39,9 @@ def init_skale(
     test_abi_filepath: str = TEST_ABI_FILEPATH,
 ) -> SkaleManager:
     wallet = Web3Wallet(eth_private_key, web3)
-    return SkaleManager(ENDPOINT, get_skale_manager_address(test_abi_filepath), wallet)
+    return SkaleManager(
+        ENDPOINT, get_skale_manager_address(test_abi_filepath), wallet, enable_stats=True
+    )
 
 
 def init_fair(web3: Web3, eth_private_key: HexStr = ETH_PRIVATE_KEY) -> FairManager:

--- a/tests/wallets/sgx_test.py
+++ b/tests/wallets/sgx_test.py
@@ -5,7 +5,6 @@ from hexbytes import HexBytes
 
 from skale.skale_manager import SkaleManager
 from skale.utils.web3_utils import (
-    init_web3,
     private_key_to_address,
     private_key_to_public,
     to_checksum_address,
@@ -20,11 +19,6 @@ from tests.constants import ENDPOINT, ETH_PRIVATE_KEY, TEST_SGX_ENDPOINT
 from tests.wallets.utils import BadSgxClient, SgxClient
 
 ADDRESS = to_checksum_address(private_key_to_address(ETH_PRIVATE_KEY))
-
-
-@pytest.fixture
-def web3():
-    return init_web3(ENDPOINT)
 
 
 @pytest.fixture

--- a/tests/wallets/sgx_test.py
+++ b/tests/wallets/sgx_test.py
@@ -4,6 +4,7 @@ import pytest
 from hexbytes import HexBytes
 
 from skale.utils.web3_utils import (
+    init_web3,
     private_key_to_address,
     private_key_to_public,
     to_checksum_address,
@@ -14,7 +15,7 @@ from skale.wallets.sgx_wallet import (
     TransactionNotSentError,
     TransactionNotSignedError,
 )
-from tests.constants import ETH_PRIVATE_KEY, TEST_SGX_ENDPOINT
+from tests.constants import ENDPOINT, ETH_PRIVATE_KEY, TEST_SGX_ENDPOINT
 from tests.wallets.utils import BadSgxClient, SgxClient
 
 ADDRESS = to_checksum_address(private_key_to_address(ETH_PRIVATE_KEY))
@@ -90,8 +91,9 @@ def test_sgx_key_init(web3):
 
 
 @mock.patch('skale.wallets.sgx_wallet.SgxClient', new=SgxClient)
-def test_not_sent_error(web3):
-    wallet = SgxWallet(TEST_SGX_ENDPOINT, web3, 'TEST_KEY')
+def test_not_sent_error():
+    w3 = init_web3(ENDPOINT)
+    wallet = SgxWallet(TEST_SGX_ENDPOINT, w3, 'TEST_KEY')
     tx_dict = {
         'to': '0x1057dc7277a319927D3eB43e05680B75a00eb5f4',
         'value': 9,

--- a/tests/wallets/sgx_test.py
+++ b/tests/wallets/sgx_test.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 from hexbytes import HexBytes
 
+from skale.skale_manager import SkaleManager
 from skale.utils.web3_utils import (
     init_web3,
     private_key_to_address,
@@ -133,3 +134,14 @@ def test_sign_hash_error(web3):
     wallet = SgxWallet(TEST_SGX_ENDPOINT, web3, 'TEST_KEY')
     with pytest.raises(MessageNotSignedError):
         wallet.sign_hash('0x')
+
+
+def test_print_stats_and_fail(skale: SkaleManager):
+    print('-------------')
+    print(
+        skale.stats.http_posts,
+        skale.stats.rpc_objects,
+        skale.stats.by_method.most_common(10),
+    )
+    print('-------------')
+    assert False

--- a/tests/wallets/sgx_test.py
+++ b/tests/wallets/sgx_test.py
@@ -3,9 +3,7 @@ from unittest import mock
 import pytest
 from hexbytes import HexBytes
 
-from skale.skale_manager import SkaleManager
 from skale.utils.web3_utils import (
-    init_web3,
     private_key_to_address,
     private_key_to_public,
     to_checksum_address,
@@ -16,15 +14,10 @@ from skale.wallets.sgx_wallet import (
     TransactionNotSentError,
     TransactionNotSignedError,
 )
-from tests.constants import ENDPOINT, ETH_PRIVATE_KEY, TEST_SGX_ENDPOINT
+from tests.constants import ETH_PRIVATE_KEY, TEST_SGX_ENDPOINT
 from tests.wallets.utils import BadSgxClient, SgxClient
 
 ADDRESS = to_checksum_address(private_key_to_address(ETH_PRIVATE_KEY))
-
-
-@pytest.fixture
-def web3():
-    return init_web3(ENDPOINT)
 
 
 @pytest.fixture
@@ -134,14 +127,3 @@ def test_sign_hash_error(web3):
     wallet = SgxWallet(TEST_SGX_ENDPOINT, web3, 'TEST_KEY')
     with pytest.raises(MessageNotSignedError):
         wallet.sign_hash('0x')
-
-
-def test_print_stats_and_fail(skale: SkaleManager):
-    print('-------------')
-    print(
-        skale.stats.http_posts,
-        skale.stats.rpc_objects,
-        skale.stats.by_method.most_common(10),
-    )
-    print('-------------')
-    assert False

--- a/tests/wallets/sgx_test.py
+++ b/tests/wallets/sgx_test.py
@@ -5,6 +5,7 @@ from hexbytes import HexBytes
 
 from skale.skale_manager import SkaleManager
 from skale.utils.web3_utils import (
+    init_web3,
     private_key_to_address,
     private_key_to_public,
     to_checksum_address,
@@ -19,6 +20,11 @@ from tests.constants import ENDPOINT, ETH_PRIVATE_KEY, TEST_SGX_ENDPOINT
 from tests.wallets.utils import BadSgxClient, SgxClient
 
 ADDRESS = to_checksum_address(private_key_to_address(ETH_PRIVATE_KEY))
+
+
+@pytest.fixture
+def web3():
+    return init_web3(ENDPOINT)
 
 
 @pytest.fixture


### PR DESCRIPTION
This pull request introduces a new mechanism for tracking and reporting HTTP and JSON-RPC usage statistics within the SKALE Python client. The main changes include the addition of a stats-tracking session class, integration of this session into the core SKALE client, and updates to utility functions to support custom HTTP sessions. These improvements provide better visibility into network activity and errors, which can aid debugging and performance analysis.

**Stats tracking and reporting:**

* Added `RpcHttpStats` dataclass and `CountingSession` class in `skale/rpc_session.py` to count HTTP POSTs, JSON-RPC objects, method usage, and transport errors for RPC calls. (`[skale/rpc_session.pyR1-R81](diffhunk://#diff-c578c5fca104b6b9904ecd58d74cb290607e176c5538bf62b50e3c767776faf1R1-R81)`)
* Integrated stats tracking into `SkaleBase` by instantiating `RpcHttpStats` and using `CountingSession` as the default HTTP session, with an option to inject a custom session. (`[[1]](diffhunk://#diff-e49d7d927663ad72e5a6545b4584afc03908b55cddf05c1f1cac48921c01dd98R54)`, `[[2]](diffhunk://#diff-e49d7d927663ad72e5a6545b4584afc03908b55cddf05c1f1cac48921c01dd98R67-R77)`)

**Web3 provider/session integration:**

* Updated `get_provider` and `init_web3` in `skale/utils/web3_utils.py` to accept and use a custom HTTP session, enabling stats tracking for RPC calls. (`[[1]](diffhunk://#diff-dc6ff999b6f9c00c738ca557cfa312a3a5595cb117f9a472bfa9fc7fdaadd525L50-R54)`, `[[2]](diffhunk://#diff-dc6ff999b6f9c00c738ca557cfa312a3a5595cb117f9a472bfa9fc7fdaadd525L59-R63)`, `[[3]](diffhunk://#diff-dc6ff999b6f9c00c738ca557cfa312a3a5595cb117f9a472bfa9fc7fdaadd525R73-R80)`)

**Testing and debugging:**

* Added a test function `test_print_stats_and_fail` in `tests/wallets/sgx_test.py` to print collected stats from `SkaleManager` and deliberately fail, facilitating inspection during test runs. (`[tests/wallets/sgx_test.pyR137-R147](diffhunk://#diff-65bf557165d5aea5f47bbce311fe742dd1d206ff7c70125a7e227a74d2675056R137-R147)`)

**Imports and dependencies:**

* Updated imports in `skale/skale_base.py`, `skale/utils/web3_utils.py`, and `tests/wallets/sgx_test.py` to include the new session and stats classes. (`[[1]](diffhunk://#diff-e49d7d927663ad72e5a6545b4584afc03908b55cddf05c1f1cac48921c01dd98R24-R29)`, `[[2]](diffhunk://#diff-dc6ff999b6f9c00c738ca557cfa312a3a5595cb117f9a472bfa9fc7fdaadd525R25)`, `[[3]](diffhunk://#diff-65bf557165d5aea5f47bbce311fe742dd1d206ff7c70125a7e227a74d2675056R6)`)