### PR TITLE
Remove schain with status structure

### DIFF
--- a/skale/contracts/manager/schains.py
+++ b/skale/contracts/manager/schains.py
@@ -38,10 +38,10 @@ from skale.dataclasses.schain_options import (
 )
 from skale.types.node import NodeId
 from skale.types.schain import (
+    Schain,
     SchainHash,
     SchainName,
     SchainStructure,
-    SchainStructureWithStatus,
 )
 from skale.utils.helper import schain_name_to_hash
 
@@ -66,7 +66,10 @@ class SChains(SkaleManagerContract):
         res = self.schains_internal.get_raw(id_)
         options = self.get_options(id_)
         return SchainStructure(
-            **asdict(res), schain_hash=schain_name_to_hash(res.name), options=options
+            **asdict(res),
+            schain_hash=schain_name_to_hash(res.name),
+            options=options,
+            active=self.schain_active(res),
         )
 
     def get_by_name(self, name: SchainName) -> SchainStructure:
@@ -83,31 +86,19 @@ class SChains(SkaleManagerContract):
             schains.append(schain)
         return schains
 
-    def get_schains_for_node(self, node_id: NodeId) -> list[SchainStructureWithStatus]:
-        schains = []
+    def get_schains_for_node(self, node_id: NodeId) -> list[SchainStructure]:
         schain_hashes = self.schains_internal.get_schain_hashes_for_node(node_id)
-        for schain_hash in schain_hashes:
-            simple_schain = self.get(schain_hash)
-            schain = SchainStructureWithStatus(
-                **asdict(simple_schain), active=self.schain_active(simple_schain)
-            )
-            schains.append(schain)
-        return schains
+        return [self.get(schain_hash) for schain_hash in schain_hashes]
 
-    def get_active_schains_for_node(self, node_id: NodeId) -> List[SchainStructureWithStatus]:
-        schains = []
+    def get_active_schains_for_node(self, node_id: NodeId) -> List[SchainStructure]:
         schain_hashes = self.schains_internal.get_active_schain_hashes_for_node(node_id)
-        for schain_hash in schain_hashes:
-            simple_schain = self.get(schain_hash)
-            schain = SchainStructureWithStatus(**asdict(simple_schain), active=True)
-            schains.append(schain)
-        return schains
+        return [self.get(schain_hash) for schain_hash in schain_hashes]
 
     def get_last_rotation_id(self, schain_name: SchainName) -> int:
         rotation_data = self.node_rotation.get_rotation(schain_name)
         return rotation_data.rotation_counter
 
-    def schain_active(self, schain: SchainStructure) -> bool:
+    def schain_active(self, schain: Schain) -> bool:
         if (
             schain.name != ''
             and schain.mainnet_owner != '0x0000000000000000000000000000000000000000'

--- a/skale/types/schain.py
+++ b/skale/types/schain.py
@@ -64,6 +64,7 @@ class Schain:
 class SchainStructure(Schain):
     schain_hash: SchainHash
     options: SchainOptions
+    active: bool
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -74,15 +75,5 @@ class SchainStructure(Schain):
                 'threshold_encryption': self.options.threshold_encryption,
                 'allocation_type': self.options.allocation_type.value,
             },
-        }
-
-
-@dataclass
-class SchainStructureWithStatus(SchainStructure):
-    active: bool
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            **super().to_dict(),
             'active': self.active,
         }

--- a/skale/utils/contracts_provision/main.py
+++ b/skale/utils/contracts_provision/main.py
@@ -51,7 +51,7 @@ from skale.utils.contracts_provision.utils import (
 )
 
 DEFAULT_MINING_INTERVAL = 1000
-TEST_SRW_FUND_VALUE = 3000000000000000000
+TEST_SRW_FUND_VALUE = 1000000000000000000
 
 
 def _skip_evm_time(web3: Web3, seconds: int, mine: bool = True) -> int:


### PR DESCRIPTION
This pull request refactors how the `active` status of a Schain is handled throughout the codebase, simplifying the data model and related methods. The main change is the removal of the `SchainStructureWithStatus` class in favor of including the `active` field directly in `SchainStructure`. Additionally, a constant value is updated for test funding.

### Data Model Simplification

* Removed the `SchainStructureWithStatus` class and added the `active` boolean field directly to the `SchainStructure` dataclass, streamlining the representation of Schain status. [[1]](diffhunk://#diff-0cf16b376964d92f37cfd367453c2972fcd733aba2ff27e0720beb3fe6fdf7cbR67) [[2]](diffhunk://#diff-0cf16b376964d92f37cfd367453c2972fcd733aba2ff27e0720beb3fe6fdf7cbL77-L86)
* Updated methods in `skale/contracts/manager/schains.py` (`get_schains_for_node`, `get_active_schains_for_node`) to return lists of `SchainStructure` with the new `active` field, eliminating the need for conversion to `SchainStructureWithStatus`.
* Changed the signature of `schain_active` to accept a `Schain` object instead of `SchainStructure`, reflecting the new unified model.

### Code Consistency

* Updated the import statements in `skale/contracts/manager/schains.py` to remove `SchainStructureWithStatus` and add `Schain`, ensuring consistency with the new data model.

### Test Configuration

* Reduced the value of `TEST_SRW_FUND_VALUE` in `skale/utils/contracts_provision/main.py` from `3000000000000000000` to `1000000000000000000` to adjust test funding parameters.