### PR TITLE
670-add-erc20_abi: add erc20_abi parameter to Erc20Contract class

### DIFF
--- a/skale/contracts/erc20_contract.py
+++ b/skale/contracts/erc20_contract.py
@@ -19,12 +19,12 @@
 
 
 from time import sleep
+from typing import Any
 
 from eth_typing import ChecksumAddress
 from web3 import Web3
 from web3.contract.contract import ContractFunction
 from web3.types import Wei
-from typing import Any
 
 from skale.contracts.base_contract import BaseContract, transaction_method
 from skale.wallets import BaseWallet

--- a/skale/contracts/erc20_contract.py
+++ b/skale/contracts/erc20_contract.py
@@ -24,6 +24,7 @@ from eth_typing import ChecksumAddress
 from web3 import Web3
 from web3.contract.contract import ContractFunction
 from web3.types import Wei
+from typing import Any
 
 from skale.contracts.base_contract import BaseContract, transaction_method
 from skale.wallets import BaseWallet
@@ -105,10 +106,11 @@ class Erc20Contract(BaseContract):
         web3: Web3,
         address: ChecksumAddress,
         wallet: BaseWallet | None = None,
-        erc20_abi: list[str] | None = ERC20_ABI,
-
+        erc20_abi: list[Any] | None = ERC20_ABI,
     ):
-        super().__init__(web3, address, erc20_abi, wallet)
+        abi_to_use = erc20_abi if erc20_abi is not None else ERC20_ABI
+
+        super().__init__(web3, address, abi_to_use, wallet)
 
     def balance_of(self, account: ChecksumAddress) -> Wei:
         return Wei(self.contract.functions.balanceOf(account).call())

--- a/skale/contracts/erc20_contract.py
+++ b/skale/contracts/erc20_contract.py
@@ -105,8 +105,10 @@ class Erc20Contract(BaseContract):
         web3: Web3,
         address: ChecksumAddress,
         wallet: BaseWallet | None = None,
+        erc20_abi: list[str] | None = ERC20_ABI,
+
     ):
-        super().__init__(web3, address, ERC20_ABI, wallet)
+        super().__init__(web3, address, erc20_abi, wallet)
 
     def balance_of(self, account: ChecksumAddress) -> Wei:
         return Wei(self.contract.functions.balanceOf(account).call())


### PR DESCRIPTION
Objective:

Allow custom ERC20 ABI injection into the Erc20Contract class for flexibility when working with different ERC20 token implementations.

Key Changes:
 - Added erc20_abi parameter to Erc20Contract.__init__() with default value of ERC20_ABI
 - Modified constructor to use the provided erc20_abi parameter instead of hardcoded ERC20_ABI constant
-  Maintains backward compatibility by defaulting to the standard ERC20 ABI

This enables developers to provide custom ABIs for ERC20 tokens with extended or modified interfaces while preserving the default behavior for standard ERC20 tokens.

