### PR TITLE
Update redis cache implementation

### DIFF
--- a/skale/skale_base.py
+++ b/skale/skale_base.py
@@ -43,16 +43,6 @@ class EmptyPrivateKey(Exception):
 class SkaleBase:
     __metaclass__ = abc.ABCMeta
 
-    DEFAULT_RPC_CACHE_TTL_POLICY: dict[str, int] = {
-        'eth_call': 10,
-        'eth_getCode': 30,
-        'eth_getStorageAt': 30,
-        'eth_chainId': 600,
-        'eth_getBlockByNumber': 60,
-        'eth_gasPrice': 5,
-        'web3_clientVersion': 600,
-    }
-
     def __init__(
         self,
         endpoint: str | list[str],
@@ -63,10 +53,7 @@ class SkaleBase:
         provider_timeout: int = 30,
         session: requests.Session | None = None,
         enable_stats: bool = False,
-        redis_cache_url: str | None = None,
-        rpc_cache_methods: list[str] | None = None,
-        rpc_cache_bypass_addresses: list[str] | None = None,
-        rpc_cache_ttl_policy: dict[str, int] | None = None,
+        redis_cache_config: RedisCacheConfig | None = None,
     ):
         logger.info(
             'Initializing %s, endpoint: %s, alias_or_address: %s, wallet: %s',
@@ -85,31 +72,12 @@ class SkaleBase:
         self._endpoint = get_endpoint(endpoint, ts_diff=ts_diff, provider_timeout=provider_timeout)
         self._alias_or_address = alias_or_address
 
-        cache_config = None
-        if redis_cache_url is not None:
-            cache_methods = rpc_cache_methods or [
-                'eth_call',
-                'eth_getCode',
-                'eth_getStorageAt',
-                'eth_chainId',
-                'eth_getBlockByNumber',
-                'eth_gasPrice',
-                'web3_clientVersion',
-            ]
-            cache_ttl_policy = rpc_cache_ttl_policy or self.DEFAULT_RPC_CACHE_TTL_POLICY
-            cache_config = RedisCacheConfig(
-                redis_url=redis_cache_url,
-                cache_methods=frozenset(cache_methods),
-                bypass_addresses=frozenset(rpc_cache_bypass_addresses or []),
-                default_ttl_seconds=0,
-                method_ttl_policy=cache_ttl_policy,
-            )
         self.web3 = init_web3(
             self._endpoint,
             ts_diff=ts_diff,
             provider_timeout=provider_timeout,
             session=session,
-            cache_config=cache_config,
+            cache_config=redis_cache_config,
         )
         self.network = skale_contracts.get_network_by_provider(self.web3.provider)
         self.project = self.network.get_project(self.project_name)

--- a/skale/utils/cache.py
+++ b/skale/utils/cache.py
@@ -21,7 +21,7 @@ import hashlib
 import json
 import logging
 from collections.abc import Mapping as ABCMapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 from redis import Redis
@@ -31,14 +31,35 @@ from web3.middleware.base import Web3Middleware
 logger = logging.getLogger(__name__)
 
 
+RPC_CACHE_METHODS: tuple[str, ...] = (
+    'eth_call',
+    'eth_getCode',
+    'eth_getStorageAt',
+    'eth_chainId',
+    'eth_getBlockByNumber',
+    'eth_gasPrice',
+    'web3_clientVersion',
+)
+
+METHOD_TTL_POLICY: dict[str, int] = {
+    'eth_call': 5,
+    'eth_getCode': 30,
+    'eth_getStorageAt': 30,
+    'eth_chainId': 600,
+    'eth_getBlockByNumber': 60,
+    'eth_gasPrice': 5,
+    'web3_clientVersion': 600,
+}
+
+
 @dataclass(frozen=True, slots=True)
 class RedisCacheConfig:
     redis_url: str
-    cache_methods: frozenset[str]
+    cache_methods: frozenset[str] = field(default_factory=lambda: frozenset(RPC_CACHE_METHODS))
     bypass_addresses: frozenset[str] = frozenset()
-    default_ttl_seconds: int = 2
+    default_ttl_seconds: int = 1
     key_prefix: str = 'rpc-cache:v1'
-    method_ttl_policy: Mapping[str, int] | None = None
+    method_ttl_policy: Mapping[str, int] = field(default_factory=lambda: METHOD_TTL_POLICY)
 
 
 def ttl_policy(


### PR DESCRIPTION
This pull request refactors how RPC cache configuration is handled in the `skale` codebase, making cache settings more centralized and easier to manage. The main changes include removing per-instance cache configuration parameters from `SkaleBase` and introducing default cache configuration values in `skale/utils/cache.py`. This streamlines cache setup and reduces redundancy.

**Cache configuration refactor:**

* Removed the `DEFAULT_RPC_CACHE_TTL_POLICY` and all cache-related initialization logic from `SkaleBase`, and replaced several `__init__` parameters with a single `redis_cache_config` parameter to simplify cache configuration (`skale/skale_base.py`). [[1]](diffhunk://#diff-e49d7d927663ad72e5a6545b4584afc03908b55cddf05c1f1cac48921c01dd98L46-L55) [[2]](diffhunk://#diff-e49d7d927663ad72e5a6545b4584afc03908b55cddf05c1f1cac48921c01dd98L66-R56) [[3]](diffhunk://#diff-e49d7d927663ad72e5a6545b4584afc03908b55cddf05c1f1cac48921c01dd98L88-R80)
* Centralized default cache methods and TTL policy as `RPC_CACHE_METHODS` and `METHOD_TTL_POLICY` constants in `skale/utils/cache.py`, and set these as defaults in the `RedisCacheConfig` dataclass (`skale/utils/cache.py`).

**Redis cache config improvements:**

* Updated `RedisCacheConfig` to use `field(default_factory=...)` for `cache_methods` and `method_ttl_policy`, ensuring default values are used unless overridden (`skale/utils/cache.py`).
* Changed the default `default_ttl_seconds` from 2 to 1 in `RedisCacheConfig` for more fine-grained cache expiration (`skale/utils/cache.py`).
* Minor import update to use `field` from `dataclasses` (`skale/utils/cache.py`).