### PR TITLE
Add new parameters to SchainOptions and update Schain config generation

### DIFF
--- a/skale/dataclasses/schain_options.py
+++ b/skale/dataclasses/schain_options.py
@@ -50,6 +50,8 @@ class SchainOptions:
             ('multitr', bool_to_bytes(self.multitransaction_mode)),
             ('encrypt', bool_to_bytes(self.threshold_encryption)),
             ('alloc', int_to_bytes(self.allocation_type.value)),
+            ('pow', hex_str_to_bytes(self.external_gas_difficulty, 32)),
+            ('gasprice', hex_str_to_bytes(self.default_gas_price, 32)),
         ]
 
 
@@ -62,17 +64,26 @@ def parse_schain_options(raw_options: list[SchainOption]) -> SchainOptions:
     multitransaction_mode = False
     threshold_encryption = False
     allocation_type = AllocationType.DEFAULT
+    external_gas_difficulty = HexStr('0x0')
+    default_gas_price = HexStr('0x0')
+
     if len(raw_options) > 0:
         multitransaction_mode = bytes_to_bool(raw_options[0][1])
     if len(raw_options) > 1:
         threshold_encryption = bytes_to_bool(raw_options[1][1])
     if len(raw_options) > 2:
         allocation_type = AllocationType(bytes_to_int(raw_options[2][1]))
+    if len(raw_options) > 3:
+        external_gas_difficulty = bytes_to_hex_str(raw_options[3][1])
+    if len(raw_options) > 4:
+        default_gas_price = bytes_to_hex_str(raw_options[4][1])
 
     return SchainOptions(
         multitransaction_mode=multitransaction_mode,
         threshold_encryption=threshold_encryption,
         allocation_type=allocation_type,
+        external_gas_difficulty=external_gas_difficulty,
+        default_gas_price=default_gas_price,
     )
 
 
@@ -81,6 +92,8 @@ def get_default_schain_options() -> SchainOptions:
         multitransaction_mode=False,
         threshold_encryption=False,
         allocation_type=AllocationType.DEFAULT,
+        external_gas_difficulty=HexStr('0x0'),
+        default_gas_price=HexStr('0x186a0'),
     )
 
 

--- a/skale/dataclasses/schain_options.py
+++ b/skale/dataclasses/schain_options.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     from skale.types.schain import SchainOption
 from enum import Enum
 
-
 from eth_typing import HexStr
 from web3 import Web3
 

--- a/skale/dataclasses/schain_options.py
+++ b/skale/dataclasses/schain_options.py
@@ -26,6 +26,9 @@ if TYPE_CHECKING:
 from enum import Enum
 
 
+from eth_typing import HexStr
+
+
 class AllocationType(int, Enum):
     DEFAULT = 0
     NO_FILESTORAGE = 1
@@ -39,6 +42,8 @@ class SchainOptions:
     multitransaction_mode: bool
     threshold_encryption: bool
     allocation_type: AllocationType
+    external_gas_difficulty: HexStr
+    default_gas_price: HexStr
 
     def to_tuples(self) -> list[SchainOption]:
         return [

--- a/skale/dataclasses/schain_options.py
+++ b/skale/dataclasses/schain_options.py
@@ -68,37 +68,30 @@ def parse_schain_options(raw_options: list[SchainOption]) -> SchainOptions:
     options_map = {k: v for k, v in raw_options}
     default_options = get_default_schain_options()
 
-    multitransaction_mode = default_options.multitransaction_mode
-    if 'multitr' in options_map:
-        multitransaction_mode = bytes_to_bool(options_map['multitr'])
-
-    threshold_encryption = default_options.threshold_encryption
-    if 'encrypt' in options_map:
-        threshold_encryption = bytes_to_bool(options_map['encrypt'])
-
-    allocation_type = default_options.allocation_type
-    if 'alloc' in options_map:
-        allocation_type = AllocationType(bytes_to_int(options_map['alloc']))
-
-    external_gas_difficulty = default_options.external_gas_difficulty
-    if 'powdifficulty' in options_map:
-        external_gas_difficulty = bytes_to_hex_str(options_map['powdifficulty'])
-
-    min_gas_price = default_options.min_gas_price
-    if 'mingasprice' in options_map:
-        min_gas_price = bytes_to_hex_str(options_map['mingasprice'])
-
-    max_gas_price = default_options.max_gas_price
-    if 'maxgasprice' in options_map:
-        max_gas_price = bytes_to_hex_str(options_map['maxgasprice'])
+    def get_val(key, converter, default):
+        return converter(options_map[key]) if key in options_map else default
 
     return SchainOptions(
-        multitransaction_mode=multitransaction_mode,
-        threshold_encryption=threshold_encryption,
-        allocation_type=allocation_type,
-        external_gas_difficulty=external_gas_difficulty,
-        min_gas_price=min_gas_price,
-        max_gas_price=max_gas_price,
+        multitransaction_mode=get_val(
+            'multitr', bytes_to_bool, default_options.multitransaction_mode
+        ),
+        threshold_encryption=get_val(
+            'encrypt', bytes_to_bool, default_options.threshold_encryption
+        ),
+        allocation_type=get_val(
+            'alloc',
+            lambda x: AllocationType(bytes_to_int(x)),
+            default_options.allocation_type,
+        ),
+        external_gas_difficulty=get_val(
+            'powdifficulty', bytes_to_hex_str, default_options.external_gas_difficulty
+        ),
+        min_gas_price=get_val(
+            'mingasprice', bytes_to_hex_str, default_options.min_gas_price
+        ),
+        max_gas_price=get_val(
+            'maxgasprice', bytes_to_hex_str, default_options.max_gas_price
+        ),
     )
 
 

--- a/skale/dataclasses/schain_options.py
+++ b/skale/dataclasses/schain_options.py
@@ -127,4 +127,4 @@ def hex_str_to_bytes(hex_str: HexStr) -> bytes:
 
 
 def bytes_to_hex_str(bytes_value: bytes) -> HexStr:
-    return HexStr(Web3.to_hex(bytes_value))
+    return Web3.to_hex(bytes_value)

--- a/skale/dataclasses/schain_options.py
+++ b/skale/dataclasses/schain_options.py
@@ -27,6 +27,7 @@ from enum import Enum
 
 
 from eth_typing import HexStr
+from web3 import Web3
 
 
 class AllocationType(int, Enum):
@@ -43,16 +44,21 @@ class SchainOptions:
     threshold_encryption: bool
     allocation_type: AllocationType
     external_gas_difficulty: HexStr
-    default_gas_price: HexStr
+    min_gas_price: HexStr | None
+    max_gas_price: HexStr | None
 
     def to_tuples(self) -> list[SchainOption]:
-        return [
+        options = [
             ('multitr', bool_to_bytes(self.multitransaction_mode)),
             ('encrypt', bool_to_bytes(self.threshold_encryption)),
             ('alloc', int_to_bytes(self.allocation_type.value)),
-            ('pow', hex_str_to_bytes(self.external_gas_difficulty, 32)),
-            ('gasprice', hex_str_to_bytes(self.default_gas_price, 32)),
+            ('powdifficulty', hex_str_to_bytes(self.external_gas_difficulty)),
         ]
+        if self.min_gas_price is not None:
+            options.append(('mingasprice', hex_str_to_bytes(self.min_gas_price)))
+        if self.max_gas_price is not None:
+            options.append(('maxgasprice', hex_str_to_bytes(self.max_gas_price)))
+        return options
 
 
 def parse_schain_options(raw_options: list[SchainOption]) -> SchainOptions:
@@ -60,30 +66,40 @@ def parse_schain_options(raw_options: list[SchainOption]) -> SchainOptions:
     Parses raw sChain options from smart contracts (list of tuples).
     Returns default values if nothing is set on contracts.
     """
+    options_map = {k: v for k, v in raw_options}
+    default_options = get_default_schain_options()
 
-    multitransaction_mode = False
-    threshold_encryption = False
-    allocation_type = AllocationType.DEFAULT
-    external_gas_difficulty = HexStr('0x0')
-    default_gas_price = HexStr('0x0')
+    multitransaction_mode = default_options.multitransaction_mode
+    if 'multitr' in options_map:
+        multitransaction_mode = bytes_to_bool(options_map['multitr'])
 
-    if len(raw_options) > 0:
-        multitransaction_mode = bytes_to_bool(raw_options[0][1])
-    if len(raw_options) > 1:
-        threshold_encryption = bytes_to_bool(raw_options[1][1])
-    if len(raw_options) > 2:
-        allocation_type = AllocationType(bytes_to_int(raw_options[2][1]))
-    if len(raw_options) > 3:
-        external_gas_difficulty = bytes_to_hex_str(raw_options[3][1])
-    if len(raw_options) > 4:
-        default_gas_price = bytes_to_hex_str(raw_options[4][1])
+    threshold_encryption = default_options.threshold_encryption
+    if 'encrypt' in options_map:
+        threshold_encryption = bytes_to_bool(options_map['encrypt'])
+
+    allocation_type = default_options.allocation_type
+    if 'alloc' in options_map:
+        allocation_type = AllocationType(bytes_to_int(options_map['alloc']))
+
+    external_gas_difficulty = default_options.external_gas_difficulty
+    if 'powdifficulty' in options_map:
+        external_gas_difficulty = bytes_to_hex_str(options_map['powdifficulty'])
+
+    min_gas_price = default_options.min_gas_price
+    if 'mingasprice' in options_map:
+        min_gas_price = bytes_to_hex_str(options_map['mingasprice'])
+
+    max_gas_price = default_options.max_gas_price
+    if 'maxgasprice' in options_map:
+        max_gas_price = bytes_to_hex_str(options_map['maxgasprice'])
 
     return SchainOptions(
         multitransaction_mode=multitransaction_mode,
         threshold_encryption=threshold_encryption,
         allocation_type=allocation_type,
         external_gas_difficulty=external_gas_difficulty,
-        default_gas_price=default_gas_price,
+        min_gas_price=min_gas_price,
+        max_gas_price=max_gas_price,
     )
 
 
@@ -92,8 +108,9 @@ def get_default_schain_options() -> SchainOptions:
         multitransaction_mode=False,
         threshold_encryption=False,
         allocation_type=AllocationType.DEFAULT,
-        external_gas_difficulty=HexStr('0x0'),
-        default_gas_price=HexStr('0x186a0'),
+        external_gas_difficulty=HexStr('0x01'),
+        min_gas_price=None,
+        max_gas_price=None,
     )
 
 
@@ -113,14 +130,9 @@ def bytes_to_bool(bytes_value: bytes) -> bool:
     return bool(int.from_bytes(bytes_value, 'big'))
 
 
-def hex_str_to_bytes(hex_str: HexStr, length: int = 32) -> bytes:
-    clean_hex = hex_str
-    if clean_hex.startswith('0x'):
-        clean_hex = clean_hex[2:]
-    val = int(clean_hex, 16)
-    return val.to_bytes(length, byteorder='big')
+def hex_str_to_bytes(hex_str: HexStr) -> bytes:
+    return Web3.to_bytes(hexstr=hex_str)
 
 
 def bytes_to_hex_str(bytes_value: bytes) -> HexStr:
-    return HexStr('0x' + bytes_value.hex())
-
+    return HexStr(Web3.to_hex(bytes_value))

--- a/skale/dataclasses/schain_options.py
+++ b/skale/dataclasses/schain_options.py
@@ -98,3 +98,16 @@ def bytes_to_int(bytes_value: bytes) -> int:
 
 def bytes_to_bool(bytes_value: bytes) -> bool:
     return bool(int.from_bytes(bytes_value, 'big'))
+
+
+def hex_str_to_bytes(hex_str: HexStr, length: int = 32) -> bytes:
+    clean_hex = hex_str
+    if clean_hex.startswith('0x'):
+        clean_hex = clean_hex[2:]
+    val = int(clean_hex, 16)
+    return val.to_bytes(length, byteorder='big')
+
+
+def bytes_to_hex_str(bytes_value: bytes) -> HexStr:
+    return HexStr('0x' + bytes_value.hex())
+

--- a/skale/types/schain.py
+++ b/skale/types/schain.py
@@ -74,6 +74,8 @@ class SchainStructure(Schain):
                 'multitransaction_mode': self.options.multitransaction_mode,
                 'threshold_encryption': self.options.threshold_encryption,
                 'allocation_type': self.options.allocation_type.value,
+                'external_gas_difficulty': self.options.external_gas_difficulty,
+                'default_gas_price': self.options.default_gas_price,
             },
             'active': self.active,
         }

--- a/skale/types/schain.py
+++ b/skale/types/schain.py
@@ -75,7 +75,8 @@ class SchainStructure(Schain):
                 'threshold_encryption': self.options.threshold_encryption,
                 'allocation_type': self.options.allocation_type.value,
                 'external_gas_difficulty': self.options.external_gas_difficulty,
-                'default_gas_price': self.options.default_gas_price,
+                'min_gas_price': self.options.min_gas_price,
+                'max_gas_price': self.options.max_gas_price,
             },
             'active': self.active,
         }

--- a/tests/manager/schains_test.py
+++ b/tests/manager/schains_test.py
@@ -157,13 +157,22 @@ def test_add_schain_by_foundation(skale, nodes):
 
 
 @pytest.mark.parametrize(
-    'mts,threshold,alloc',
+    'mts,threshold,alloc,pow_difficulty,min_gas,max_gas',
     [
-        (True, False, AllocationType.MAX_CONSENSUS_DB),
-        (False, True, AllocationType.MAX_FILESTORAGE),
+        (True, False, AllocationType.MAX_CONSENSUS_DB, HexStr('0x01'), None, None),
+        (
+            False,
+            True,
+            AllocationType.MAX_FILESTORAGE,
+            HexStr('0x02'),
+            HexStr('0x0100'),
+            HexStr('0x0200'),
+        ),
     ],
 )
-def test_add_schain_by_foundation_with_options(mts, threshold, alloc, skale, nodes):
+def test_add_schain_by_foundation_with_options(
+    mts, threshold, alloc, pow_difficulty, min_gas, max_gas, skale, nodes
+):
     skale.schains.grant_role(skale.schains.schain_creator_role(), skale.wallet.address)
     _, lifetime_seconds, name = generate_random_schain_data(skale)
     type_of_nodes = 1  # test2 schain
@@ -177,9 +186,9 @@ def test_add_schain_by_foundation_with_options(mts, threshold, alloc, skale, nod
                 multitransaction_mode=mts,
                 threshold_encryption=threshold,
                 allocation_type=alloc,
-                external_gas_difficulty=HexStr('0x01'),
-                min_gas_price=None,
-                max_gas_price=None,
+                external_gas_difficulty=pow_difficulty,
+                min_gas_price=min_gas,
+                max_gas_price=max_gas,
             ),
             wait_for=True,
         )
@@ -188,6 +197,9 @@ def test_add_schain_by_foundation_with_options(mts, threshold, alloc, skale, nod
         assert schain.options.multitransaction_mode is mts
         assert schain.options.threshold_encryption is threshold
         assert schain.options.allocation_type is alloc
+        assert schain.options.external_gas_difficulty == pow_difficulty
+        assert schain.options.min_gas_price == min_gas
+        assert schain.options.max_gas_price == max_gas
     finally:
         skale.manager.delete_schain(name)
 

--- a/tests/manager/schains_test.py
+++ b/tests/manager/schains_test.py
@@ -3,9 +3,10 @@
 import pytest
 from hexbytes import HexBytes
 from web3 import Web3
+from eth_typing import HexStr
 
 from skale.contracts.manager.schains import SchainStructure
-from skale.dataclasses.schain_options import AllocationType, SchainOptions
+from skale.dataclasses.schain_options import AllocationType, SchainOptions, hex_str_to_bytes
 from skale.skale_manager import SkaleManager
 from skale.utils.contracts_provision.fake_multisig_contract import (
     FAKE_MULTISIG_DATA_PATH,
@@ -44,6 +45,9 @@ def test_get_by_name(skale, schain):
         multitransaction_mode=False,
         threshold_encryption=False,
         allocation_type=AllocationType.DEFAULT,
+        external_gas_difficulty=HexStr('0x01'),
+        min_gas_price=None,
+        max_gas_price=None,
     )
 
 
@@ -68,6 +72,9 @@ def test_schain_get_object(skale, schain):
         multitransaction_mode=False,
         threshold_encryption=False,
         allocation_type=AllocationType.DEFAULT,
+        external_gas_difficulty=HexStr('0x01'),
+        min_gas_price=None,
+        max_gas_price=None,
     )
 
 
@@ -112,6 +119,9 @@ def test_all_schain_hashes(skale, schain):
         multitransaction_mode=False,
         threshold_encryption=False,
         allocation_type=AllocationType.DEFAULT,
+        external_gas_difficulty=HexStr('0x01'),
+        min_gas_price=None,
+        max_gas_price=None,
     )
 
 
@@ -167,6 +177,9 @@ def test_add_schain_by_foundation_with_options(mts, threshold, alloc, skale, nod
                 multitransaction_mode=mts,
                 threshold_encryption=threshold,
                 allocation_type=alloc,
+                external_gas_difficulty=HexStr('0x01'),
+                min_gas_price=None,
+                max_gas_price=None,
             ),
             wait_for=True,
         )
@@ -269,6 +282,9 @@ def test_options(skale, nodes):
         multitransaction_mode=True,
         threshold_encryption=False,
         allocation_type=AllocationType.DEFAULT,
+        external_gas_difficulty=HexStr('0x01'),
+        min_gas_price=HexStr('0x0100'),
+        max_gas_price=HexStr('0x0200'),
     )
     name = None
     try:
@@ -283,6 +299,9 @@ def test_options(skale, nodes):
             ('multitr', b'\x01'),
             ('encrypt', b'\x00'),
             ('alloc', b'\x00'),
+            ('powdifficulty', b'\x01'),
+            ('mingasprice', b'\x01\x00'),
+            ('maxgasprice', b'\x02\x00'),
         ]
 
     finally:

--- a/tests/manager/schains_test.py
+++ b/tests/manager/schains_test.py
@@ -147,6 +147,9 @@ def test_add_schain_by_foundation(skale, nodes):
         assert schain.options.multitransaction_mode is False
         assert schain.options.threshold_encryption is False
         assert schain.options.allocation_type is AllocationType.DEFAULT
+        assert schain.options.external_gas_difficulty == HexStr('0x01')
+        assert schain.options.min_gas_price is None
+        assert schain.options.max_gas_price is None
     finally:
         skale.manager.delete_schain(name, wait_for=True)
 
@@ -168,6 +171,7 @@ def test_add_schain_by_foundation(skale, nodes):
             HexStr('0x0100'),
             HexStr('0x0200'),
         ),
+        (False, False, AllocationType.DEFAULT, HexStr('0x01'), HexStr('0x1000'), None),
     ],
 )
 def test_add_schain_by_foundation_with_options(

--- a/tests/manager/schains_test.py
+++ b/tests/manager/schains_test.py
@@ -1,12 +1,12 @@
 """SKALE chain test"""
 
 import pytest
+from eth_typing import HexStr
 from hexbytes import HexBytes
 from web3 import Web3
-from eth_typing import HexStr
 
 from skale.contracts.manager.schains import SchainStructure
-from skale.dataclasses.schain_options import AllocationType, SchainOptions, hex_str_to_bytes
+from skale.dataclasses.schain_options import AllocationType, SchainOptions
 from skale.skale_manager import SkaleManager
 from skale.utils.contracts_provision.fake_multisig_contract import (
     FAKE_MULTISIG_DATA_PATH,


### PR DESCRIPTION
This pull request extends the `SchainOptions` data model to support additional gas-related configuration options and updates related serialization, parsing logic, and tests to handle these new fields. The main focus is on adding support for `external_gas_difficulty`, `min_gas_price`, and `max_gas_price` as part of sChain options, ensuring these are correctly handled throughout the codebase and tested accordingly.

**Enhancements to sChain Options:**

* Added new fields to the `SchainOptions` dataclass: `external_gas_difficulty`, `min_gas_price`, and `max_gas_price`, with corresponding changes to the `to_tuples` method for serialization and the `parse_schain_options` function for deserialization. [[1]](diffhunk://#diff-c7c5c6112b5b3530aa2b78c0b688a9ea0f480712fbd9f959b11e1de2579740bdR45-R101) [[2]](diffhunk://#diff-c7c5c6112b5b3530aa2b78c0b688a9ea0f480712fbd9f959b11e1de2579740bdR110-R112)
* Introduced utility functions `hex_str_to_bytes` and `bytes_to_hex_str` for conversion between hex strings and bytes, used in the new gas-related fields.

**Updates to Serialization and Default Values:**

* Updated the default values in `get_default_schain_options()` to include the new fields, ensuring backward compatibility and consistent defaults.
* Modified the `to_dict` method in `skale/types/schain.py` to include the new gas-related options in the output dictionary.

**Testing Improvements:**

* Updated and expanded tests in `tests/manager/schains_test.py` to cover the new fields, including test parameterization for different gas option scenarios and validation of correct serialization/deserialization. [[1]](diffhunk://#diff-6a5cd82f75e134f9db99b8f86d7e2e86896a213378d4c317fe9ccf4f55264227R48-R50) [[2]](diffhunk://#diff-6a5cd82f75e134f9db99b8f86d7e2e86896a213378d4c317fe9ccf4f55264227R75-R77) [[3]](diffhunk://#diff-6a5cd82f75e134f9db99b8f86d7e2e86896a213378d4c317fe9ccf4f55264227R122-R124) [[4]](diffhunk://#diff-6a5cd82f75e134f9db99b8f86d7e2e86896a213378d4c317fe9ccf4f55264227L150-R175) [[5]](diffhunk://#diff-6a5cd82f75e134f9db99b8f86d7e2e86896a213378d4c317fe9ccf4f55264227R189-R191) [[6]](diffhunk://#diff-6a5cd82f75e134f9db99b8f86d7e2e86896a213378d4c317fe9ccf4f55264227R200-R202) [[7]](diffhunk://#diff-6a5cd82f75e134f9db99b8f86d7e2e86896a213378d4c317fe9ccf4f55264227R297-R299) [[8]](diffhunk://#diff-6a5cd82f75e134f9db99b8f86d7e2e86896a213378d4c317fe9ccf4f55264227R314-R316)
* Added necessary imports for `HexStr` in test files to support the new types.