### PR TITLE
Save schain gas price parameters as integer

### DIFF
--- a/skale/dataclasses/schain_options.py
+++ b/skale/dataclasses/schain_options.py
@@ -43,8 +43,8 @@ class SchainOptions:
     threshold_encryption: bool
     allocation_type: AllocationType
     external_gas_difficulty: HexStr
-    min_gas_price: HexStr | None
-    max_gas_price: HexStr | None
+    min_gas_price: int | None
+    max_gas_price: int | None
 
     def to_tuples(self) -> list[SchainOption]:
         options = [
@@ -54,9 +54,9 @@ class SchainOptions:
             ('powdifficulty', hex_str_to_bytes(self.external_gas_difficulty)),
         ]
         if self.min_gas_price is not None:
-            options.append(('mingasprice', hex_str_to_bytes(self.min_gas_price)))
+            options.append(('mingasprice', int_to_bytes(self.min_gas_price)))
         if self.max_gas_price is not None:
-            options.append(('maxgasprice', hex_str_to_bytes(self.max_gas_price)))
+            options.append(('maxgasprice', int_to_bytes(self.max_gas_price)))
         return options
 
 
@@ -86,12 +86,8 @@ def parse_schain_options(raw_options: list[SchainOption]) -> SchainOptions:
         external_gas_difficulty=get_val(
             'powdifficulty', bytes_to_hex_str, default_options.external_gas_difficulty
         ),
-        min_gas_price=get_val(
-            'mingasprice', bytes_to_hex_str, default_options.min_gas_price
-        ),
-        max_gas_price=get_val(
-            'maxgasprice', bytes_to_hex_str, default_options.max_gas_price
-        ),
+        min_gas_price=get_val('mingasprice', bytes_to_int, default_options.min_gas_price),
+        max_gas_price=get_val('maxgasprice', bytes_to_int, default_options.max_gas_price),
     )
 
 
@@ -111,7 +107,7 @@ def bool_to_bytes(bool_value: bool) -> bytes:
 
 
 def int_to_bytes(int_value: int) -> bytes:
-    return int.to_bytes(int_value, length=1, byteorder='big')
+    return int_value.to_bytes(max(1, (int_value.bit_length() + 7) // 8), byteorder='big')
 
 
 def bytes_to_int(bytes_value: bytes) -> int:

--- a/tests/manager/schains_test.py
+++ b/tests/manager/schains_test.py
@@ -168,10 +168,10 @@ def test_add_schain_by_foundation(skale, nodes):
             True,
             AllocationType.MAX_FILESTORAGE,
             HexStr('0x02'),
-            HexStr('0x0100'),
-            HexStr('0x0200'),
+            256,
+            512,
         ),
-        (False, False, AllocationType.DEFAULT, HexStr('0x01'), HexStr('0x1000'), None),
+        (False, False, AllocationType.DEFAULT, HexStr('0x01'), 4096, None),
     ],
 )
 def test_add_schain_by_foundation_with_options(
@@ -299,8 +299,8 @@ def test_options(skale, nodes):
         threshold_encryption=False,
         allocation_type=AllocationType.DEFAULT,
         external_gas_difficulty=HexStr('0x01'),
-        min_gas_price=HexStr('0x0100'),
-        max_gas_price=HexStr('0x0200'),
+        min_gas_price=256,
+        max_gas_price=512,
     )
     name = None
     try:


### PR DESCRIPTION
This pull request updates the representation and handling of `min_gas_price` and `max_gas_price` in the `SchainOptions` dataclass and related logic. The changes improve type consistency by switching these fields from `HexStr` to `int`, and update serialization and deserialization functions accordingly. Associated tests are also updated to use integer values.

**Type and Serialization Updates**

* Changed the types of `min_gas_price` and `max_gas_price` in the `SchainOptions` dataclass from `HexStr | None` to `int | None` for better clarity and type safety.
* Updated the `to_tuples` method to serialize `min_gas_price` and `max_gas_price` using `int_to_bytes` instead of `hex_str_to_bytes`.
* Modified deserialization logic to use `bytes_to_int` for `min_gas_price` and `max_gas_price` instead of `bytes_to_hex_str`.
* Improved the `int_to_bytes` utility to dynamically determine the required byte length, ensuring correct conversion for any integer value.

**Test Updates**

* Updated test cases in `tests/manager/schains_test.py` to use integer values for `min_gas_price` and `max_gas_price` instead of `HexStr`. [[1]](diffhunk://#diff-6a5cd82f75e134f9db99b8f86d7e2e86896a213378d4c317fe9ccf4f55264227L171-R174) [[2]](diffhunk://#diff-6a5cd82f75e134f9db99b8f86d7e2e86896a213378d4c317fe9ccf4f55264227L302-R303)