### PR TITLE
update settings structure, add new fields, update tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,8 @@
 - no redundant code - move repeated logic into helper functions
 - use type hints to specify the expected types of function arguments and return values
 
-- check `ruff.toml` for formatting rules
-- always lint changes using `ruff check`
+- check `pyproject.toml` for formatting rules
+- always lint changes using `uv run ruff check`
 - tests should be placed in `tests/` directory, follow the existing structure and code style
+- always use `uv` to run all commands in the repo (e.g., `uv run ruff`, `uv run pytest`, etc.)
+- for running tests, export environment variables in the terminal before running the tests: `. ./scripts/export_env.sh`

--- a/skale/core/settings.py
+++ b/skale/core/settings.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import overload
 
 import tomli_w
-from pydantic import AnyUrl, BaseModel, field_validator
+from pydantic import AnyUrl, field_validator
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -55,25 +55,26 @@ class TomlBaseSettings(BaseSettings):
         )
 
 
-class NodeSettings(TomlBaseSettings):
+class InternalSettings(TomlBaseSettings):
     node_type: NodeType
     node_mode: NodeMode
+
+    skale_dir_host: Path
+
+    @field_validator('skale_dir_host', mode='before')
+    @classmethod
+    def validate_skale_dir_host(cls, value: Path | str) -> Path:
+        return Path(value).expanduser().resolve()
+
+    @property
+    def node_data_path_host(self) -> Path:
+        return self.skale_dir_host / 'node_data'
 
     model_config = SettingsConfigDict(extra='forbid')
 
 
-class SkaleContracts(BaseModel):
-    manager: str
-    ima: str
-
-
-class FairContracts(BaseModel):
-    fair: str
-
-
-class BaseAdminSettings(TomlBaseSettings):
+class BaseNodeSettings(TomlBaseSettings):
     env_type: EnvType
-    skale_dir_host: Path
     endpoint: AnyUrl
 
     backup_run: bool = False
@@ -90,36 +91,45 @@ class BaseAdminSettings(TomlBaseSettings):
 
     disable_colors: bool = False
 
-    @field_validator('skale_dir_host', mode='before')
-    @classmethod
-    def validate_skale_dir_host(cls, value: Path | str) -> Path:
-        return Path(value).expanduser().resolve()
+    # node-cli level settings
 
-    @property
-    def node_data_path_host(self) -> Path:
-        return self.skale_dir_host / 'node_data'
+    node_version: str
+    block_device: str
+
+    filebeat_host: str = ''
+    container_configs_dir: str = ''
+    skip_docker_config: bool = False
+    skip_docker_cleanup: bool = False
 
     model_config = SettingsConfigDict(env_nested_delimiter=NESTED_DELIMITER)
 
 
-class SkaleBaseSettings(BaseAdminSettings):
-    contracts: SkaleContracts
+class _SkaleBaseSettings(BaseNodeSettings):
+    manager_contracts: str
+    ima_contracts: str
 
 
-class ActiveSettings(BaseAdminSettings):
+class ActiveSettings(BaseNodeSettings):
     sgx_url: AnyUrl
 
 
-class SkaleSettings(SkaleBaseSettings, ActiveSettings):
+class SkaleSettings(_SkaleBaseSettings, ActiveSettings):
     sgx_url: AnyUrl
+    docker_lvmpy_version: str
+
+    disable_dry_run: bool = False
+    default_gas_limit: int | None = None
+    default_gas_price_wei: int | None = None
 
 
-class SkalePassiveSettings(SkaleBaseSettings):
+class SkalePassiveSettings(_SkaleBaseSettings):
     schain_name: SchainName
+    enforce_btrfs: bool = False
 
 
-class FairBaseSettings(BaseAdminSettings):
-    contracts: FairContracts
+class FairBaseSettings(BaseNodeSettings):
+    fair_contracts: str
+    enforce_btrfs: bool = False
 
 
 class FairSettings(FairBaseSettings, ActiveSettings):
@@ -127,11 +137,11 @@ class FairSettings(FairBaseSettings, ActiveSettings):
 
 
 @lru_cache
-def get_node_settings() -> NodeSettings:
-    return NodeSettings()  # type: ignore[call-arg]
+def get_node_settings() -> InternalSettings:
+    return InternalSettings()  # type: ignore[call-arg]
 
 
-SETTINGS_MAP: dict[tuple[NodeType, NodeMode], type[BaseAdminSettings]] = {
+SETTINGS_MAP: dict[tuple[NodeType, NodeMode], type[BaseNodeSettings]] = {
     ('skale', 'passive'): SkalePassiveSettings,
     ('skale', 'active'): SkaleSettings,
     ('fair', 'passive'): FairBaseSettings,
@@ -139,16 +149,16 @@ SETTINGS_MAP: dict[tuple[NodeType, NodeMode], type[BaseAdminSettings]] = {
 }
 
 
-def _resolve_type(node_type: NodeType, node_mode: NodeMode) -> type[BaseAdminSettings]:
-    return SETTINGS_MAP.get((node_type, node_mode), BaseAdminSettings)
+def _resolve_type(node_type: NodeType, node_mode: NodeMode) -> type[BaseNodeSettings]:
+    return SETTINGS_MAP.get((node_type, node_mode), BaseNodeSettings)
 
 
 @overload
-def get_settings() -> BaseAdminSettings: ...
+def get_settings() -> BaseNodeSettings: ...
 @overload
-def get_settings[T: BaseAdminSettings](return_type: type[T]) -> T: ...
+def get_settings[T: BaseNodeSettings](return_type: type[T]) -> T: ...
 @overload
-def get_settings[T1: BaseAdminSettings, T2: BaseAdminSettings](
+def get_settings[T1: BaseNodeSettings, T2: BaseNodeSettings](
     return_type: tuple[type[T1], type[T2]],
 ) -> T1 | T2: ...
 
@@ -164,19 +174,19 @@ def get_settings(return_type=None):
     return settings_cls()  # type: ignore[call-arg]
 
 
-def write_node_settings_file(
+def write_internal_settings_file(
     *,
     path: Path,
     node_type: NodeType,
     node_mode: NodeMode,
-) -> NodeSettings:
-    cfg = NodeSettings.model_validate({'node_type': node_type, 'node_mode': node_mode})
+) -> InternalSettings:
+    cfg = InternalSettings.model_validate({'node_type': node_type, 'node_mode': node_mode})
     data = cfg.model_dump(mode='json', exclude_none=True)
     _atomic_write_text(path, tomli_w.dumps(data))
     return cfg
 
 
-def write_admin_settings_file[T: BaseAdminSettings](
+def write_node_settings_file[T: BaseNodeSettings](
     *,
     path: Path,
     settings_type: type[T],

--- a/skale/core/settings.py
+++ b/skale/core/settings.py
@@ -137,7 +137,7 @@ class FairSettings(FairBaseSettings, ActiveSettings):
 
 
 @lru_cache
-def get_node_settings() -> InternalSettings:
+def get_internal_settings() -> InternalSettings:
     return InternalSettings()  # type: ignore[call-arg]
 
 
@@ -169,7 +169,7 @@ def get_settings(return_type=None):
             return_type = None
         else:
             return return_type()  # type: ignore[call-arg]
-    node_settings = get_node_settings()
+    node_settings = get_internal_settings()
     settings_cls = _resolve_type(node_settings.node_type, node_settings.node_mode)
     return settings_cls()  # type: ignore[call-arg]
 

--- a/tests/core/settings_test.py
+++ b/tests/core/settings_test.py
@@ -5,25 +5,24 @@ import pytest
 from pydantic import ValidationError
 
 from skale.core.settings import (
-    BaseAdminSettings,
+    BaseNodeSettings,
     FairBaseSettings,
     FairSettings,
     SkalePassiveSettings,
     SkaleSettings,
     _resolve_type,
-    write_admin_settings_file,
+    write_internal_settings_file,
     write_node_settings_file,
 )
 from skale.core.types import NodeMode, NodeType
 
-BASE_ADMIN_DATA = {
+BASE_NODE_DATA = {
     'env_type': 'mainnet',
-    'skale_dir_host': '/tmp/skale',
     'endpoint': 'http://localhost:8545',
+    'node_version': '1.0.0',
+    'block_device': '/dev/sda',
 }
 
-SKALE_CONTRACTS = {'manager': '0x1', 'ima': '0x2'}
-FAIR_CONTRACTS = {'fair': '0x3'}
 SGX_URL = 'https://sgx.example.com'
 
 
@@ -39,47 +38,73 @@ def node_type_mode(request: pytest.FixtureRequest) -> tuple[NodeType, NodeMode]:
     return request.param
 
 
-def test_write_node_settings(tmp_path: Path, node_type_mode: tuple[NodeType, NodeMode]) -> None:
+def test_write_internal_settings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    node_type_mode: tuple[NodeType, NodeMode],
+) -> None:
     node_type, node_mode = node_type_mode
+    monkeypatch.setenv('SKALE_DIR_HOST', str(tmp_path))
     path = tmp_path / 'node.toml'
-    result = write_node_settings_file(path=path, node_type=node_type, node_mode=node_mode)
+    result = write_internal_settings_file(path=path, node_type=node_type, node_mode=node_mode)
     assert result.node_type == node_type
     assert result.node_mode == node_mode
     with open(path, 'rb') as f:
         data = tomllib.load(f)
-    assert data == {'node_type': node_type, 'node_mode': node_mode}
+    assert data['node_type'] == node_type
+    assert data['node_mode'] == node_mode
 
 
-def test_write_node_settings_invalid_type(tmp_path: Path) -> None:
+def test_write_internal_settings_invalid_type(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv('SKALE_DIR_HOST', str(tmp_path))
     with pytest.raises(ValidationError):
-        write_node_settings_file(
+        write_internal_settings_file(
             path=tmp_path / 'node.toml', node_type='unknown', node_mode='active'
         )
 
 
 @pytest.fixture(
     params=[
-        (SkaleSettings, {**BASE_ADMIN_DATA, 'contracts': SKALE_CONTRACTS, 'sgx_url': SGX_URL}),
+        (
+            SkaleSettings,
+            {
+                **BASE_NODE_DATA,
+                'manager_contracts': '0x1',
+                'ima_contracts': '0x2',
+                'sgx_url': SGX_URL,
+                'docker_lvmpy_version': '1.0.0',
+            },
+        ),
         (
             SkalePassiveSettings,
-            {**BASE_ADMIN_DATA, 'contracts': SKALE_CONTRACTS, 'schain_name': 'test-chain'},
+            {
+                **BASE_NODE_DATA,
+                'manager_contracts': '0x1',
+                'ima_contracts': '0x2',
+                'schain_name': 'test-chain',
+            },
         ),
-        (FairBaseSettings, {**BASE_ADMIN_DATA, 'contracts': FAIR_CONTRACTS}),
-        (FairSettings, {**BASE_ADMIN_DATA, 'contracts': FAIR_CONTRACTS, 'sgx_url': SGX_URL}),
+        (FairBaseSettings, {**BASE_NODE_DATA, 'fair_contracts': '0x3'}),
+        (
+            FairSettings,
+            {**BASE_NODE_DATA, 'fair_contracts': '0x3', 'sgx_url': SGX_URL},
+        ),
     ]
 )
-def admin_settings_entry(
+def node_settings_entry(
     request: pytest.FixtureRequest,
-) -> tuple[type[BaseAdminSettings], dict]:
+) -> tuple[type[BaseNodeSettings], dict]:
     return request.param
 
 
-def test_write_admin_settings(
-    tmp_path: Path, admin_settings_entry: tuple[type[BaseAdminSettings], dict]
+def test_write_node_settings(
+    tmp_path: Path, node_settings_entry: tuple[type[BaseNodeSettings], dict]
 ) -> None:
-    settings_type, data = admin_settings_entry
-    path = tmp_path / 'admin.toml'
-    result = write_admin_settings_file(path=path, settings_type=settings_type, data=data)
+    settings_type, data = node_settings_entry
+    path = tmp_path / 'settings.toml'
+    result = write_node_settings_file(path=path, settings_type=settings_type, data=data)
     assert isinstance(result, settings_type)
     assert str(result.endpoint) == data['endpoint'] + '/'
     assert path.exists()
@@ -88,10 +113,10 @@ def test_write_admin_settings(
     assert written['env_type'] == data['env_type']
 
 
-def test_admin_settings_rejects_missing_fields(tmp_path: Path) -> None:
+def test_node_settings_rejects_missing_fields(tmp_path: Path) -> None:
     with pytest.raises(ValidationError):
-        write_admin_settings_file(
-            path=tmp_path / 'admin.toml',
+        write_node_settings_file(
+            path=tmp_path / 'settings.toml',
             settings_type=SkaleSettings,
             data={'env_type': 'mainnet'},
         )
@@ -102,4 +127,4 @@ def test_resolve_type() -> None:
     assert _resolve_type('skale', 'passive') is SkalePassiveSettings
     assert _resolve_type('fair', 'active') is FairSettings
     assert _resolve_type('fair', 'passive') is FairBaseSettings
-    assert _resolve_type('skale', 'unknown') is BaseAdminSettings
+    assert _resolve_type('skale', 'unknown') is BaseNodeSettings


### PR DESCRIPTION
This pull request refactors the settings module to clarify and unify the distinction between internal/node settings and admin settings, and updates the related tests and documentation accordingly. The changes focus on renaming classes and functions for clarity, consolidating and simplifying the settings hierarchy, and ensuring tests and documentation reflect the new structure.

**Settings module refactor and simplification:**

* Renamed `NodeSettings` to `InternalSettings`, and `BaseAdminSettings` to `BaseNodeSettings`, updating all references and function signatures accordingly. This clarifies the purpose of each settings class and function throughout the codebase. [[1]](diffhunk://#diff-9e038e2fbf53da000045f1e93df53ae7033b667de400d7f979b8efa8a9cb1392L58-L76) [[2]](diffhunk://#diff-9e038e2fbf53da000045f1e93df53ae7033b667de400d7f979b8efa8a9cb1392L93-R161) [[3]](diffhunk://#diff-9e038e2fbf53da000045f1e93df53ae7033b667de400d7f979b8efa8a9cb1392L167-R189)
* Simplified the contracts configuration by replacing the `SkaleContracts` and `FairContracts` models with direct string fields (`manager_contracts`, `ima_contracts`, `fair_contracts`) in the corresponding settings classes. [[1]](diffhunk://#diff-9e038e2fbf53da000045f1e93df53ae7033b667de400d7f979b8efa8a9cb1392L58-L76) [[2]](diffhunk://#diff-9e038e2fbf53da000045f1e93df53ae7033b667de400d7f979b8efa8a9cb1392L93-R161)
* Updated the settings resolution logic and type hints to use the new class names, ensuring type safety and consistency. [[1]](diffhunk://#diff-9e038e2fbf53da000045f1e93df53ae7033b667de400d7f979b8efa8a9cb1392L93-R161) [[2]](diffhunk://#diff-9e038e2fbf53da000045f1e93df53ae7033b667de400d7f979b8efa8a9cb1392L167-R189)

**Test updates:**

* Refactored tests to use the new class and function names, updated fixtures and test data to match the new settings model, and improved environment setup using `monkeypatch` for environment variables. [[1]](diffhunk://#diff-dd3463fcd1a7cd1ac23c7cf93f1b4ea6fb21e954745936d049a7283288c9773aL8-L26) [[2]](diffhunk://#diff-dd3463fcd1a7cd1ac23c7cf93f1b4ea6fb21e954745936d049a7283288c9773aL42-R107) [[3]](diffhunk://#diff-dd3463fcd1a7cd1ac23c7cf93f1b4ea6fb21e954745936d049a7283288c9773aL91-R119) [[4]](diffhunk://#diff-dd3463fcd1a7cd1ac23c7cf93f1b4ea6fb21e954745936d049a7283288c9773aL105-R130)

**Documentation improvements:**

* Updated `.github/copilot-instructions.md` to reference `pyproject.toml` for formatting rules, require use of `uv` for all commands, and clarify environment variable setup for tests.