### PR TITLE
Update settings write functions

### DIFF
--- a/skale/core/settings.py
+++ b/skale/core/settings.py
@@ -61,6 +61,9 @@ class InternalSettings(TomlBaseSettings):
 
     skale_dir_host: Path
 
+    backup_run: bool = False
+    pull_config_for_schain: str | None = None
+
     @field_validator('skale_dir_host', mode='before')
     @classmethod
     def validate_skale_dir_host(cls, value: Path | str) -> Path:
@@ -77,8 +80,6 @@ class BaseNodeSettings(TomlBaseSettings):
     env_type: EnvType
     endpoint: AnyUrl
 
-    backup_run: bool = False
-    pull_config_for_schain: str | None = None
     bite: bool = False
 
     tg_api_key: str | None = None
@@ -100,6 +101,7 @@ class BaseNodeSettings(TomlBaseSettings):
     container_configs_dir: str = ''
     skip_docker_config: bool = False
     skip_docker_cleanup: bool = False
+    monitoring_containers: bool = False
 
     model_config = SettingsConfigDict(env_nested_delimiter=NESTED_DELIMITER)
 
@@ -174,23 +176,15 @@ def get_settings(return_type=None):
     return settings_cls()  # type: ignore[call-arg]
 
 
-def write_internal_settings_file(
-    *,
-    path: Path,
-    node_type: NodeType,
-    node_mode: NodeMode,
-) -> InternalSettings:
-    cfg = InternalSettings.model_validate({'node_type': node_type, 'node_mode': node_mode})
-    data = cfg.model_dump(mode='json', exclude_none=True)
-    _atomic_write_text(path, tomli_w.dumps(data))
+def write_internal_settings_file(*, path: Path, data: dict) -> InternalSettings:
+    cfg = InternalSettings.model_validate(data)
+    dumped = cfg.model_dump(mode='json', exclude_none=True)
+    _atomic_write_text(path, tomli_w.dumps(dumped))
     return cfg
 
 
 def write_node_settings_file[T: BaseNodeSettings](
-    *,
-    path: Path,
-    settings_type: type[T],
-    data: dict,
+    *, path: Path, settings_type: type[T], data: dict
 ) -> T:
     cfg = settings_type.model_validate(data)
     dumped = cfg.model_dump(mode='json', exclude_none=True)

--- a/tests/core/settings_test.py
+++ b/tests/core/settings_test.py
@@ -46,7 +46,8 @@ def test_write_internal_settings(
     node_type, node_mode = node_type_mode
     monkeypatch.setenv('SKALE_DIR_HOST', str(tmp_path))
     path = tmp_path / 'node.toml'
-    result = write_internal_settings_file(path=path, node_type=node_type, node_mode=node_mode)
+    data = {'node_type': node_type, 'node_mode': node_mode, 'skale_dir_host': str(tmp_path)}
+    result = write_internal_settings_file(path=path, data=data)
     assert result.node_type == node_type
     assert result.node_mode == node_mode
     with open(path, 'rb') as f:
@@ -61,7 +62,8 @@ def test_write_internal_settings_invalid_type(
     monkeypatch.setenv('SKALE_DIR_HOST', str(tmp_path))
     with pytest.raises(ValidationError):
         write_internal_settings_file(
-            path=tmp_path / 'node.toml', node_type='unknown', node_mode='active'
+            path=tmp_path / 'node.toml',
+            data={'node_type': 'unknown', 'node_mode': 'active', 'skale_dir_host': str(tmp_path)},
         )
 
 


### PR DESCRIPTION
This pull request refactors and extends the settings management in `skale/core/settings.py`. The main changes involve moving certain configuration fields from `BaseNodeSettings` to `InternalSettings`, introducing a new field for container monitoring, and simplifying the logic for writing internal settings files.

**Settings structure changes:**

* Moved the `backup_run` and `pull_config_for_schain` fields from `BaseNodeSettings` to `InternalSettings`, centralizing their configuration. [[1]](diffhunk://#diff-9e038e2fbf53da000045f1e93df53ae7033b667de400d7f979b8efa8a9cb1392R64-R66) [[2]](diffhunk://#diff-9e038e2fbf53da000045f1e93df53ae7033b667de400d7f979b8efa8a9cb1392L80-L81)
* Added a new boolean field `monitoring_containers` to `BaseNodeSettings` to enable or disable container monitoring.

**Refactoring and simplification:**

* Refactored the `write_internal_settings_file` function to accept a data dictionary directly, simplifying its interface and removing the need to pass `node_type` and `node_mode` separately.