### PR TITLE
fix versions for core package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,11 @@ jobs:
           enable-cache: true
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
+      - name: Calculate version
+        run: |
+          export BRANCH=${GITHUB_REF##*/}
+          export VERSION=$(bash ./scripts/calculate_version.sh)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Build skale.py-core
         run: bash ./scripts/build_core.sh
       - name: Publish skale.py-core

--- a/packages/skale-core/pyproject.toml
+++ b/packages/skale-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skale.py-core"
-version = "0.1.0"
+version = "0.0.0"
 description = "SKALE core settings and types"
 readme = "README.md"
 requires-python = ">=3.11,<4"

--- a/scripts/build_core.sh
+++ b/scripts/build_core.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-VERSION=$(grep '^version = ' packages/skale-core/pyproject.toml | cut -d'"' -f2)
+VERSION=${VERSION:-$(grep '^version = ' pyproject.toml | cut -d'"' -f2)}
+
+sed -i "s/version = \".*\"/version = \"${VERSION}\"/g" packages/skale-core/pyproject.toml
 
 rm -rf packages/skale-core/dist/*
 

--- a/scripts/publish_core.sh
+++ b/scripts/publish_core.sh
@@ -12,6 +12,5 @@ else
     uv publish --username "$PIP_USERNAME" --password "$PIP_PASSWORD" packages/skale-core/dist/*
 fi
 
-VERSION=$(grep '^version = ' packages/skale-core/pyproject.toml | cut -d'"' -f2)
 echo "==================================================================="
 echo "Uploaded to pypi, check at https://pypi.org/project/skale.py-core/$VERSION/"


### PR DESCRIPTION
This pull request introduces improvements to the versioning and build process for the `skale.py-core` Python package. The main focus is on dynamically calculating and setting the package version during the build and publish workflows, rather than relying on a hardcoded value.

**Build and Versioning Automation:**

* The GitHub Actions workflow (`.github/workflows/publish.yml`) now includes a step to calculate the package version dynamically using the `calculate_version.sh` script and sets it as an environment variable for subsequent steps.
* The `build_core.sh` script has been updated to set the version in `pyproject.toml` based on the calculated or provided `VERSION` environment variable, ensuring the correct version is used during builds.
* The `version` field in `packages/skale-core/pyproject.toml` is now set to a placeholder value (`0.0.0`), which will be replaced during the build process.

**Miscellaneous:**

* The unused version extraction line has been removed from `scripts/publish_core.sh` to avoid confusion, as the version is now set earlier in the process.