### PR TITLE
fix default value for disable_colors setting

### DIFF
--- a/packages/skale-core/skale_core/settings.py
+++ b/packages/skale-core/skale_core/settings.py
@@ -89,7 +89,7 @@ class BaseNodeSettings(TomlBaseSettings):
 
     influx_url: AnyUrl | None = None
 
-    disable_colors: bool = False
+    disable_colors: bool = True
 
     # node-cli level settings
 


### PR DESCRIPTION
This pull request makes a small configuration change to the `BaseNodeSettings` class in `skale_core/settings.py`. The change sets the default value of `disable_colors` to `True`, which will disable colored output by default for node CLI operations.