### PR TITLE
update credit station contracts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skale.py"
-version = "7.13"
+version = "7.14"
 description = "SKALE client tools"
 readme = "README.md"
 requires-python = ">=3.11,<4"
@@ -24,25 +24,20 @@ dependencies = [
     "skale-contracts==2.0.0a10",
     "skale.py-core",
     "typing-extensions==4.15.0",
-    "web3==7.14.1",
+    "web3==7.15.0",
     "multisigwallet-predeployed==1.1.0b0",
 ]
 
 [project.optional-dependencies]
-linter = [
-    "ruff==0.15.2",
-    "mypy==1.19.1",
-    "isort>=4.2.15,<5.4.3",
-    "importlib-metadata<9.0",
-]
-hw-wallet = ["ledgerblue==0.1.55"]
+linter = ["ruff==0.15.12", "mypy==1.20.2"]
+hw-wallet = ["ledgerblue==0.1.56"]
 dev = [
     "skale.py[linter,hw-wallet]",
     "codecov",
     "freezegun==1.5.5",
     "mock==5.2.0",
-    "pytest==9.0.2",
-    "pytest-cov==7.0.0",
+    "pytest==9.0.3",
+    "pytest-cov==7.1.0",
     "pytest-timeout==2.4.0",
     "types-requests",
     "types-redis",

--- a/skale/contracts/credit_station/credit_station.py
+++ b/skale/contracts/credit_station/credit_station.py
@@ -61,9 +61,13 @@ def get_events_in_chunks(
 class CreditStation(SkaleContract):
     @transaction_method
     def buy(
-        self, schain_name: SchainName, purchaser: ChecksumAddress, token: ChecksumAddress
+        self,
+        schain_name: SchainName,
+        purchaser: ChecksumAddress,
+        token: ChecksumAddress,
+        value: Wei,
     ) -> ContractFunction:
-        return self.contract.functions.buy(schain_name, purchaser, token)
+        return self.contract.functions.buy(schain_name, purchaser, token, value)
 
     @transaction_method
     def set_price(self, token: ChecksumAddress, price: Wei) -> ContractFunction:
@@ -105,6 +109,7 @@ class CreditStation(SkaleContract):
                 from_address=event['args']['from'],
                 to_address=event['args']['to'],
                 token_address=event['args']['tokenAddress'],
+                value=event['args']['value'],
                 block_number=event['blockNumber'],
             )
             for event in events

--- a/skale/types/credit_station.py
+++ b/skale/types/credit_station.py
@@ -30,4 +30,5 @@ class PaymentReceivedEvent(TypedDict):
     from_address: ChecksumAddress
     to_address: ChecksumAddress
     token_address: ChecksumAddress
+    value: int
     block_number: int


### PR DESCRIPTION
This pull request updates dependencies, introduces a minor version bump, and adds support for a new parameter in the `CreditStation` contract's `buy` method and related event handling.

Dependency and version updates:

* Bumped the package version from `7.13` to `7.14` in `pyproject.toml`.
* Updated several dependencies in `pyproject.toml`, including `web3` (to `7.15.0`), linter/dev tools, and `ledgerblue` (to `0.1.56`).

CreditStation contract and event changes:

* Modified the `CreditStation.buy` method to accept an additional `value` parameter and pass it to the contract call.
* Updated the `PaymentReceivedEvent` type to include a new `value: int` field.
* Adjusted event parsing in `get_payment_received_events` to populate the new `value` field from the event arguments.